### PR TITLE
Change PropTypes of ProtectedRoute component

### DIFF
--- a/src/components/ProtectedRoute/index.js
+++ b/src/components/ProtectedRoute/index.js
@@ -25,7 +25,10 @@ const ProtectedRoute = ({ component: Component, ...rest }) => {
 };
 
 ProtectedRoute.propTypes = {
-  component: PropTypes.func.isRequired,
+  component : PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.func,
+  ]).isRequired,
 };
 
 export default ProtectedRoute;


### PR DESCRIPTION
Change PropTypes to allow this behavior:

```javascript
const component = <div>Foooooo</div>;
<ProtectedRoute component={component} />;
```