### PR TITLE
Add hook for authentication and remove unused selectors

### DIFF
--- a/src/components/ProtectedRoute/index.js
+++ b/src/components/ProtectedRoute/index.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 import { Redirect, Route, useLocation } from 'react-router-dom';
 
-import { checkAuthentication } from 'selectors/auth';
+import { useAuthentication } from 'hooks/auth';
 
 const ProtectedRoute = ({ children, ...rest }) => {
   const location = useLocation();
-  const isAuthenticated = useSelector(checkAuthentication);
+  const { isAuthenticated } = useAuthentication();
 
   return isAuthenticated ? (
     <Route {...rest}>{children}</Route>

--- a/src/components/SignIn/index.js
+++ b/src/components/SignIn/index.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useSelector } from 'react-redux';
 import { Link, Redirect, useLocation } from 'react-router-dom';
 
-import { checkAuthentication } from 'selectors/auth';
+import { useAuthentication } from 'hooks/auth';
 import Form from './Form';
 import style from './index.module.scss';
 
 const SignIn = () => {
   const { state } = useLocation();
   const { from } = state || { from: { pathname: '/' } };
-  const isAuthenticated = useSelector(checkAuthentication);
+  const { isAuthenticated } = useAuthentication();
 
   if (isAuthenticated) {
     return <Redirect to={from} />;

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useSelector } from 'react-redux';
 import { Link, Redirect, useLocation } from 'react-router-dom';
 
-import { checkAuthentication } from 'selectors/auth';
+import { useAuthentication } from 'hooks/auth';
 import Form from './Form';
 
 const SignUp = () => {
   const { state } = useLocation();
   const { from } = state || { from: { pathname: '/' } };
-  const isAuthenticated = useSelector(checkAuthentication);
+  const { isAuthenticated } = useAuthentication();
 
   if (isAuthenticated) {
     return <Redirect to={from} />;

--- a/src/hooks/auth.js
+++ b/src/hooks/auth.js
@@ -1,0 +1,11 @@
+import { useSelector, shallowEqual } from 'react-redux';
+
+export const useAuthentication = () => {
+  return useSelector(
+    ({ auth: { user, userSession } }) => ({
+      isAuthenticated: userSession !== null,
+      user,
+    }),
+    shallowEqual
+  );
+};

--- a/src/layouts/AuthLayout.js
+++ b/src/layouts/AuthLayout.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const AuthLayout = ({ children }) => {

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const MainLayout = ({ children }) => {

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -3,6 +3,7 @@ import { persistReducer } from 'redux-persist';
 import { ActionType } from 'redux-promise-middleware';
 
 import Types from 'actions/types';
+import createReducer from 'reducers/createReducer';
 
 const { Fulfilled, Pending } = ActionType;
 
@@ -33,11 +34,7 @@ const handlers = {
   [`${Types.SIGN_OUT}_${Pending}`]: signOut,
 };
 
-const authReducer = (state = initialState, { type, payload }) => {
-  const handler = handlers[type];
-
-  return handler ? handler(state, payload) : state;
-};
+const authReducer = createReducer(initialState, handlers);
 
 const authPersistConfig = {
   storage,

--- a/src/reducers/createReducer.js
+++ b/src/reducers/createReducer.js
@@ -1,0 +1,7 @@
+export default (initialState, handlers) => {
+  return (state = initialState, { type, payload }) => {
+    const handler = handlers[type];
+
+    return handler ? handler(state, payload) : state;
+  };
+};

--- a/src/selectors/auth.js
+++ b/src/selectors/auth.js
@@ -1,7 +1,0 @@
-export const checkAuthentication = ({ auth: { userSession } }) => {
-  return userSession !== null;
-};
-
-export const getUser = ({ auth: { user } }) => {
-  return user;
-};


### PR DESCRIPTION
* Also created generic helper for creating reducers

The generic helper assumes that every action should send its data inside a payload
attribute. You can see the reason for this [here](https://redux.js.org/style-guide/style-guide/#write-actions-using-the-flux-standard-action-convention)