### PR TITLE
Remove babel-eslint from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "autoprefixer": "^9.7.4",
     "axios": "^0.19.2",
-    "formik": "2.1.4",
     "flat": "^5.0.0",
+    "formik": "2.1.4",
     "humps": "^2.0.1",
     "node-sass": "^4.13.1",
     "postcss-cli": "^7.1.0",
@@ -55,7 +55,6 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.1.1",
     "@testing-library/react": "^9.4.1",
-    "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "18.0.1",
     "eslint-config-prettier": "^6.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,7 +2823,7 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-eslint@10.0.3, babel-eslint@^10.0.3:
+babel-eslint@10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
   integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==


### PR DESCRIPTION
#### :page_facing_up: Description:

Remove babel-eslint from devDependencies since is included in react-scripts.