### PR TITLE
Add tests for navigation on user authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^2.5.0",
     "eslint-plugin-testing-library": "^2.2.3",
+    "history": "^4.10.1",
     "prettier": "^1.19.1",
     "tailwindcss": "^1.2.0"
   }

--- a/src/components/SignIn/SignIn.test.js
+++ b/src/components/SignIn/SignIn.test.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { fillInput, fireEvent, render, wait } from 'testUtils';
+import {
+  fillInput,
+  fireEvent,
+  render,
+  renderWithRouter,
+  wait,
+} from 'testUtils';
 import { mockSignInSuccess, mockSignInFailure } from 'testUtils/mocks/auth';
 import fakeAuthService from 'api/AuthService';
 import SignIn from '.';
@@ -17,7 +23,9 @@ describe('SignIn', () => {
   it('should submit correctly', async () => {
     mockSignInSuccess();
 
-    const { getByTestId } = render(<SignIn />);
+    const { getByTestId, history } = renderWithRouter(<SignIn />, {
+      route: '/sign-in',
+    });
     const submitButton = getByTestId('submit-button');
     const email = getByTestId('email-input');
     const password = getByTestId('password-input');
@@ -37,6 +45,7 @@ describe('SignIn', () => {
 
     expect(fakeAuthService.signIn).toHaveBeenCalledTimes(1);
     expect(fakeAuthService.signIn).toHaveBeenCalledWith(fakeCredentials);
+    expect(history.location.pathname).toMatch('/');
   });
 
   it('should show error on response failure', async () => {

--- a/src/components/SignUp/SignUp.test.js
+++ b/src/components/SignUp/SignUp.test.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { fillInput, fireEvent, render, wait } from 'testUtils';
+import {
+  fillInput,
+  fireEvent,
+  render,
+  renderWithRouter,
+  wait,
+} from 'testUtils';
 import { mockSignUpSuccess, mockSignUpFailure } from 'testUtils/mocks/auth';
 import fakeAuthService from 'api/AuthService';
 import SignUp from '.';
@@ -19,7 +25,9 @@ describe('SignUp', () => {
   it('should submit correctly', async () => {
     mockSignUpSuccess();
 
-    const { getByTestId } = render(<SignUp />);
+    const { getByTestId, history } = renderWithRouter(<SignUp />, {
+      route: '/sign-up',
+    });
     const email = getByTestId('email-input');
     const firstName = getByTestId('firstName-input');
     const lastName = getByTestId('lastName-input');
@@ -45,6 +53,7 @@ describe('SignUp', () => {
 
     expect(fakeAuthService.signUp).toHaveBeenCalledTimes(1);
     expect(fakeAuthService.signUp).toHaveBeenCalledWith(fakeCredentials);
+    expect(history.location.pathname).toMatch('/');
   });
 
   it('should show error on response failure', async () => {

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -5,6 +5,7 @@ import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 
 import AppLocale from 'languageProvider';
 import createStore from 'testUtils/store';
@@ -25,9 +26,17 @@ const renderWithProviders = (ui, options) => {
   return render(ui, { wrapper: Wrapper, ...options });
 };
 
+function renderWithRouter(ui, options) {
+  const history = createMemoryHistory({ initialEntries: [options.route] });
+  return {
+    ...renderWithProviders(ui, options),
+    history,
+  };
+}
+
 // re-export everything
 export * from '@testing-library/react';
 export * from './fieldHelpers';
 
 // override render method
-export { renderWithProviders as render };
+export { renderWithProviders as render, renderWithRouter };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5951,7 +5951,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@^4.9.0:
+history@^4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==


### PR DESCRIPTION
#### :page_facing_up: Description:

Add tests for `signup` and `signin` to test after the user authenticates in both, this one will be redirected to the dashboard.

---

#### :pushpin: Notes:

- Used `react-testing-library` https://testing-library.com/docs/example-react-router examples to add the new function `renderWithRouter`.

---

#### :heavy_check_mark: Tasks:

- Imitate the `signup` and `signin` flow adding at the end the check to see on which url the user is now.