### PR TITLE
Add nock to mock api requests on tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://test.com/api/v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ![react app banner](https://user-images.githubusercontent.com/7807521/75348990-9eb6e300-5882-11ea-856d-fb11f426b602.png)
 
 <p align="center"><strong>An opinionated boilerplate code for starting a new react web project.</strong></p>
@@ -6,7 +5,6 @@
 <sub> Created and maintained with ❤️ by <a href="[https://loopstudio.dev/](https://loopstudio.dev/)">LoopStudio</a> </sub>
 
 ## Table of Contents
-
 - [Project Structure](#project-structure)
 - [Features](#features)
 - [Prerequisites](#prerequisites)
@@ -78,6 +76,7 @@
 ### Testing:
 - [jest](https://jestjs.io/): a delightful JavaScript Testing Framework with a focus on simplicity.
 - [react-testing-library](https://testing-library.com/docs/react-testing-library/intro): a very light-weight solution for testing React components.
+- [nock](https://github.com/nock/nock): HTTP server mocking and expectations library for Node.js
 - [cypress](https://www.cypress.io/): automated integration tests. This tool isn't installed in our project, but we recommend to use it. You can install it running `yarn add cypress --dev`. For more information about the configuration you can read [this guide](https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements)
 
 ## Getting Started
@@ -89,8 +88,7 @@
 ## Running the Test Suite
 1. Run the `yarn test` command.
 
-Credits
---------
+## Credits
 React App Boilerplate is maintained by [Loopstudio](https://loopstudio.dev).
 
 [<img src='https://loopstudio.dev/wp-content/uploads/2019/05/logoblack.png' width='300'/>](https://loopstudio.dev)

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-react-hooks": "^2.5.0",
     "eslint-plugin-testing-library": "^2.2.3",
     "history": "^4.10.1",
+    "nock": "^12.0.2",
     "prettier": "^1.19.1",
     "tailwindcss": "^1.2.0"
   }

--- a/src/api/__mocks__/AuthService.js
+++ b/src/api/__mocks__/AuthService.js
@@ -1,7 +1,0 @@
-const AuthService = jest.mock('../AuthService');
-
-AuthService.signUp = jest.fn(() => Promise.resolve());
-AuthService.signIn = jest.fn(() => Promise.resolve());
-AuthService.signOut = jest.fn(() => Promise.resolve());
-
-export default AuthService;

--- a/src/components/SignIn/SignIn.test.js
+++ b/src/components/SignIn/SignIn.test.js
@@ -9,10 +9,7 @@ import {
   wait,
 } from 'testUtils';
 import { mockSignInSuccess, mockSignInFailure } from 'testUtils/mocks/auth';
-import fakeAuthService from 'api/AuthService';
 import SignIn from '.';
-
-jest.mock('api/AuthService');
 
 const fakeCredentials = {
   email: 'user@example.com',
@@ -21,7 +18,7 @@ const fakeCredentials = {
 
 describe('SignIn', () => {
   it('should submit correctly', async () => {
-    mockSignInSuccess();
+    const mockedRequest = mockSignInSuccess(fakeCredentials);
 
     const { getByTestId, history } = renderWithRouter(<SignIn />, {
       route: '/sign-in',
@@ -43,13 +40,12 @@ describe('SignIn', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(fakeAuthService.signIn).toHaveBeenCalledTimes(1);
-    expect(fakeAuthService.signIn).toHaveBeenCalledWith(fakeCredentials);
+    expect(mockedRequest.isDone()).toBeTruthy();
     expect(history.location.pathname).toMatch('/');
   });
 
   it('should show error on response failure', async () => {
-    mockSignInFailure();
+    const mockedRequest = mockSignInFailure(fakeCredentials);
 
     const { getByTestId, queryByText } = render(<SignIn />);
     const submitButton = getByTestId('submit-button');
@@ -69,9 +65,11 @@ describe('SignIn', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(fakeAuthService.signIn).toHaveBeenCalledTimes(1);
-    expect(fakeAuthService.signIn).toHaveBeenCalledWith(fakeCredentials);
-    expect(queryByText('There was an error.')).toBeInTheDocument();
+    expect(mockedRequest.isDone()).toBeTruthy();
+
+    await wait(() => {
+      expect(queryByText('There was an error.')).toBeInTheDocument();
+    });
   });
 
   it('should disable the submit button for invalid values', async () => {

--- a/src/components/SignUp/SignUp.test.js
+++ b/src/components/SignUp/SignUp.test.js
@@ -9,12 +9,9 @@ import {
   wait,
 } from 'testUtils';
 import { mockSignUpSuccess, mockSignUpFailure } from 'testUtils/mocks/auth';
-import fakeAuthService from 'api/AuthService';
 import SignUp from '.';
 
-jest.mock('api/AuthService');
-
-const fakeCredentials = {
+const fakeUser = {
   email: 'user@example.com',
   firstName: 'User',
   lastName: 'Example',
@@ -23,7 +20,7 @@ const fakeCredentials = {
 
 describe('SignUp', () => {
   it('should submit correctly', async () => {
-    mockSignUpSuccess();
+    const mockedRequest = mockSignUpSuccess(fakeUser);
 
     const { getByTestId, history } = renderWithRouter(<SignUp />, {
       route: '/sign-up',
@@ -35,29 +32,28 @@ describe('SignUp', () => {
     const submitButton = getByTestId('submit-button');
 
     await wait(() => {
-      fillInput(email, fakeCredentials.email);
-      fillInput(firstName, fakeCredentials.firstName);
-      fillInput(lastName, fakeCredentials.lastName);
-      fillInput(password, fakeCredentials.password);
+      fillInput(email, fakeUser.email);
+      fillInput(firstName, fakeUser.firstName);
+      fillInput(lastName, fakeUser.lastName);
+      fillInput(password, fakeUser.password);
     });
 
     expect(submitButton).toBeEnabled();
-    expect(email.value).toBe(fakeCredentials.email);
-    expect(firstName.value).toBe(fakeCredentials.firstName);
-    expect(lastName.value).toBe(fakeCredentials.lastName);
-    expect(password.value).toBe(fakeCredentials.password);
+    expect(email.value).toBe(fakeUser.email);
+    expect(firstName.value).toBe(fakeUser.firstName);
+    expect(lastName.value).toBe(fakeUser.lastName);
+    expect(password.value).toBe(fakeUser.password);
 
     await wait(() => {
       fireEvent.click(submitButton);
     });
 
-    expect(fakeAuthService.signUp).toHaveBeenCalledTimes(1);
-    expect(fakeAuthService.signUp).toHaveBeenCalledWith(fakeCredentials);
+    expect(mockedRequest.isDone()).toBeTruthy();
     expect(history.location.pathname).toMatch('/');
   });
 
   it('should show error on response failure', async () => {
-    mockSignUpFailure();
+    const mockedRequest = mockSignUpFailure(fakeUser);
 
     const { getByTestId, queryByText } = render(<SignUp />);
     const email = getByTestId('email-input');
@@ -67,25 +63,27 @@ describe('SignUp', () => {
     const submitButton = getByTestId('submit-button');
 
     await wait(() => {
-      fillInput(email, fakeCredentials.email);
-      fillInput(firstName, fakeCredentials.firstName);
-      fillInput(lastName, fakeCredentials.lastName);
-      fillInput(password, fakeCredentials.password);
+      fillInput(email, fakeUser.email);
+      fillInput(firstName, fakeUser.firstName);
+      fillInput(lastName, fakeUser.lastName);
+      fillInput(password, fakeUser.password);
     });
 
     expect(submitButton).toBeEnabled();
-    expect(email.value).toBe(fakeCredentials.email);
-    expect(firstName.value).toBe(fakeCredentials.firstName);
-    expect(lastName.value).toBe(fakeCredentials.lastName);
-    expect(password.value).toBe(fakeCredentials.password);
+    expect(email.value).toBe(fakeUser.email);
+    expect(firstName.value).toBe(fakeUser.firstName);
+    expect(lastName.value).toBe(fakeUser.lastName);
+    expect(password.value).toBe(fakeUser.password);
 
     await wait(() => {
       fireEvent.click(submitButton);
     });
 
-    expect(fakeAuthService.signUp).toHaveBeenCalledTimes(1);
-    expect(fakeAuthService.signUp).toHaveBeenCalledWith(fakeCredentials);
-    expect(queryByText('There was an error.')).toBeInTheDocument();
+    expect(mockedRequest.isDone()).toBeTruthy();
+
+    await wait(() => {
+      expect(queryByText('There was an error.')).toBeInTheDocument();
+    });
   });
 
   it('should disable the submit button for invalid values', async () => {

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -1,51 +1,52 @@
-import fakeAuthService from 'api/AuthService';
+import humps from 'humps';
+import baseMock from './base';
 
 const userResponse = {
-  data: {
-    user: {
-      id: 1,
-      first_name: 'Thomas',
-      last_name: 'Shelby',
-      email: 'tommy@shelbyltd.com',
+  body: {
+    data: {
+      user: {
+        id: 1,
+        first_name: 'User',
+        last_name: 'Example',
+        email: 'user@example.com',
+      },
     },
   },
   headers: {
-    uid: 'tommy@shelbyltd.com',
+    uid: 'user@example.com',
     client: 'client',
     'access-token': 'token',
   },
 };
 
-export const mockSignUpSuccess = () => {
-  fakeAuthService.signUp.mockImplementation(() =>
-    Promise.resolve(userResponse)
-  );
+export const mockSignUpSuccess = (user) => {
+  return baseMock
+    .post('/users', humps.decamelizeKeys({ user }))
+    .reply(200, userResponse.body, userResponse.headers);
 };
 
-export const mockSignUpFailure = () => {
-  fakeAuthService.signUp.mockImplementation(() =>
-    Promise.reject({
-      data: {
-        attributes_errors: {
-          email: 'has already been taken',
-        },
+export const mockSignUpFailure = (user) => {
+  return baseMock.post('/users', humps.decamelizeKeys({ user })).reply(422, {
+    data: {
+      attributes_errors: {
+        email: 'has already been taken',
       },
-    })
-  );
+    },
+  });
 };
 
-export const mockSignInSuccess = () => {
-  fakeAuthService.signIn.mockImplementation(() =>
-    Promise.resolve(userResponse)
-  );
+export const mockSignInSuccess = (credentials) => {
+  return baseMock
+    .post('/users/sign_in', humps.decamelizeKeys({ user: credentials }))
+    .reply(200, userResponse.body, userResponse.headers);
 };
 
-export const mockSignInFailure = () => {
-  fakeAuthService.signIn.mockImplementation(() =>
-    Promise.reject({
+export const mockSignInFailure = (credentials) => {
+  return baseMock
+    .post('/users/sign_in', humps.decamelizeKeys({ user: credentials }))
+    .reply(403, {
       data: {
         errors: ['The credentials are not valid'],
       },
-    })
-  );
+    });
 };

--- a/src/testUtils/mocks/base.js
+++ b/src/testUtils/mocks/base.js
@@ -1,0 +1,7 @@
+import nock from 'nock';
+import axios from 'axios';
+import httpAdapter from 'axios/lib/adapters/http';
+
+axios.defaults.adapter = httpAdapter;
+
+export default nock(process.env.REACT_APP_API_URL);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7377,7 +7377,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -8135,6 +8135,16 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+nock@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-12.0.2.tgz#47617b34738e026b29d2294b4579e35b27e6a4d3"
+  integrity sha512-pTckyfP8QHvwXP/oX+zQuSIL3S/mWTd84ba4pOGZlS/FgRZyljv4C3ZyOjgMilvkydSaERML/aJEF13EBUuDTQ==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.13"
+    propagate "^2.0.0"
 
 node-emoji@^1.8.1:
   version "1.10.0"
@@ -9796,6 +9806,11 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-expr@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### :page_facing_up: Description:

Jest mocks for mocking api request are not so good, so the idea of this PR is to start using [nock](https://github.com/nock/nock) for that

---
#### :heavy_check_mark: Tasks:

* Add nock as a dev dependency
* Remove old jest mocks
* Create new mocks for API calls using nock