### PR TITLE
Move token logic from httpClient to interceptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,6 @@
     "prestart": "yarn build:styles",
     "pre-push": "eslint ."
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
-  "jest": {
-    "resetMocks": true
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/api/AuthService.js
+++ b/src/api/AuthService.js
@@ -1,20 +1,20 @@
-import axiosClient from './httpClient';
+import httpClient from './httpClient';
 
 class AuthService {
-  static signUp = (user) => axiosClient().post('/users', { user });
+  static signUp = (user) => httpClient.post('/users', { user });
 
   static signIn = (credentials) =>
-    axiosClient().post('/users/sign_in', { user: credentials });
+    httpClient.post('/users/sign_in', { user: credentials });
 
-  static signOut = () => axiosClient().delete('/users/sign_out');
+  static signOut = () => httpClient.delete('/users/sign_out');
 
   static resetPassword = (email) =>
-    axiosClient().post('/users/password', { email });
+    httpClient.post('/users/password', { email });
 
   static updatePassword = (password) =>
-    axiosClient().patch('/users/password', { password });
+    httpClient.patch('/users/password', { password });
 
-  static updateUser = (user) => axiosClient().patch('/users', { user });
+  static updateUser = (user) => httpClient.patch('/users', { user });
 }
 
 export default AuthService;


### PR DESCRIPTION
#### :page_facing_up: Description:

Move token logic from httpClient to interceptors to avoid creating a new axios client on
every request

* Also removed unnecessary config from package.json

@loopstudio/react-devs
