### PR TITLE
Remove duplication from Select and Input components

### DIFF
--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
+
+import Label from './Label';
 
 import styles from './Form.module.scss';
 
@@ -9,16 +9,12 @@ const FormInput = React.forwardRef(
   ({ error, helpLinkPath, helpMessage, id, name, label, ...rest }, ref) => (
     <div className={error ? styles.invalid : styles.valid}>
       <label htmlFor={id} className={styles.label}>
-        <div className={styles.labelContainer}>
-          <span className={styles.span}>
-            {label || <FormattedMessage id={`common.${name}`} />}
-          </span>
-          {helpLinkPath && (
-            <Link className={styles.link} to={helpLinkPath}>
-              {helpMessage}
-            </Link>
-          )}
-        </div>
+        <Label
+          name={name}
+          helpLinkPath={helpLinkPath}
+          helpMessage={helpMessage}
+          label={label}
+        />
         <input {...rest} name={name} className={styles.input} ref={ref} />
       </label>
       <span className={styles.error}>{error}</span>

--- a/src/components/Form/Label.js
+++ b/src/components/Form/Label.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
+
+import styles from './Form.module.scss';
+
+const Label = ({ helpLinkPath, helpMessage, name, label }) => (
+  <div className={styles.labelContainer}>
+    <span className={styles.span}>
+      {label || <FormattedMessage id={`common.${name}`} />}
+    </span>
+    {helpLinkPath && (
+      <Link className={styles.link} to={helpLinkPath}>
+        {helpMessage}
+      </Link>
+    )}
+  </div>
+);
+
+Label.defaultProps = {
+  helpLinkPath: '',
+  helpMessage: '',
+  label: null,
+};
+
+Label.propTypes = {
+  name: PropTypes.string.isRequired,
+  helpLinkPath: PropTypes.string,
+  helpMessage: PropTypes.string,
+  label: PropTypes.string,
+};
+
+export default Label;

--- a/src/components/Form/Select.js
+++ b/src/components/Form/Select.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
+
+import Label from './Label';
 
 import styles from './Form.module.scss';
 
@@ -25,16 +26,12 @@ const FormSelect = React.forwardRef(
     return (
       <div className={error ? styles.invalid : styles.valid}>
         <label htmlFor={id} className={styles.label}>
-          <div className={styles.labelContainer}>
-            <span className={styles.span}>
-              {label || <FormattedMessage id={`common.${name}`} />}
-            </span>
-            {helpLinkPath && (
-              <Link className={styles.link} to={helpLinkPath}>
-                {helpMessage}
-              </Link>
-            )}
-          </div>
+          <Label
+            name={name}
+            helpLinkPath={helpLinkPath}
+            helpMessage={helpMessage}
+            label={label}
+          />
           <select
             {...rest}
             aria-label={intl.messages[`common.${name}`]}


### PR DESCRIPTION
#### :page_facing_up: Description:

Select and Input components had some duplication on their label. This PR extracts that duplication to a separate component and use it instead

@loopstudio/react-devs
