### PR TITLE
Fix styles

### DIFF
--- a/src/components/AuthWrapper/AuthWrapper.module.scss
+++ b/src/components/AuthWrapper/AuthWrapper.module.scss
@@ -18,7 +18,7 @@
     .max-w-sm,
     .mb-4,
     .px-12,
-    .py-16,
+    .py-10,
     .rounded,
     .shadow-lg;
 }
@@ -33,7 +33,7 @@
 .title {
   @extend
     .font-light,
-    .mb-20,
+    .mb-12,
     .self-center,
     .text-2xl,
     .text-3xl,

--- a/src/components/ForgotPassword/ForgotPassword.module.scss
+++ b/src/components/ForgotPassword/ForgotPassword.module.scss
@@ -11,3 +11,7 @@
 .success {
   @extend .text-green-700;
 }
+
+.emailInput {
+  @extend .w-full;
+}

--- a/src/components/ForgotPassword/Form.js
+++ b/src/components/ForgotPassword/Form.js
@@ -42,6 +42,7 @@ const ForgotPasswordForm = () => {
             <FormattedMessage id="common.forgotPasswordLegend" />
           </p>
           <Form.Input
+            className={styles.emailInput}
             id="email"
             name="email"
             type="email"

--- a/src/components/Form/Form.module.scss
+++ b/src/components/Form/Form.module.scss
@@ -61,7 +61,8 @@
 .button {
   @extend .bg-indigo-600,
     .font-bold,
-    .my-10,
+    .mt-10,
+    .mb-6,
     .px-4,
     .py-2,
     .rounded-full,

--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -6,7 +6,10 @@ import Label from './Label';
 import styles from './Form.module.scss';
 
 const FormInput = React.forwardRef(
-  ({ error, helpLinkPath, helpMessage, id, name, label, ...rest }, ref) => (
+  (
+    { error, helpLinkPath, helpMessage, id, name, label, className, ...rest },
+    ref
+  ) => (
     <div className={error ? styles.invalid : styles.valid}>
       <label htmlFor={id} className={styles.label}>
         <Label
@@ -15,7 +18,12 @@ const FormInput = React.forwardRef(
           helpMessage={helpMessage}
           label={label}
         />
-        <input {...rest} name={name} className={styles.input} ref={ref} />
+        <input
+          {...rest}
+          name={name}
+          className={`${styles.input} ${className}`}
+          ref={ref}
+        />
       </label>
       <span className={styles.error}>{error}</span>
     </div>
@@ -23,24 +31,26 @@ const FormInput = React.forwardRef(
 );
 
 FormInput.defaultProps = {
+  className: '',
   error: '',
-  value: '',
-  type: 'text',
   helpLinkPath: '',
   helpMessage: '',
   label: null,
+  type: 'text',
+  value: '',
 };
 
 FormInput.propTypes = {
+  className: PropTypes.string,
   error: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
+  helpLinkPath: PropTypes.string,
+  helpMessage: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string,
   name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
   type: PropTypes.string,
   value: PropTypes.string,
-  helpLinkPath: PropTypes.string,
-  id: PropTypes.string.isRequired,
-  helpMessage: PropTypes.string,
-  label: PropTypes.string,
 };
 
 export default FormInput;


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR fixes the email input in the forgot password form and reduce the padding of the auth card to decrease the amount of white space.

<img width="1440" alt="Screen Shot 2020-05-05 at 13 32 28" src="https://user-images.githubusercontent.com/7807521/81091264-5a287300-8ed5-11ea-9427-a7a7f365632e.png">
<img width="1440" alt="Screen Shot 2020-05-05 at 13 32 36" src="https://user-images.githubusercontent.com/7807521/81091268-5bf23680-8ed5-11ea-99bf-ba97fc9ca3cc.png">
<img width="1440" alt="Screen Shot 2020-05-05 at 13 32 20" src="https://user-images.githubusercontent.com/7807521/81091269-5c8acd00-8ed5-11ea-8231-ced0d1706640.png">

<img width="419" alt="Screen Shot 2020-05-05 at 10 10 05" src="https://user-images.githubusercontent.com/7807521/81069680-98fc0000-8eb8-11ea-91f5-54a95921eceb.png">
