### PR TITLE
Improve error handling and Fix sign-out

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,6 @@
     "react/forbid-prop-types": "off",
     "react/jsx-props-no-spreading": "off",
     "react/jsx-filename-extension": "off",
-    "no-throw-literal": "off"
+    "prefer-promise-reject-errors": "off"
   }
 }

--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -35,14 +35,14 @@ httpClient.interceptors.response.use(
   (response) => response,
   (error) => {
     if (!error.response) {
-      throw { errors: ['Connection error'] };
+      return Promise.reject({ errors: ['Connection error'] });
     }
 
     if (error.response.status === 401) {
       store.dispatch(clearSession());
     }
 
-    throw error.response.data;
+    return Promise.reject(error.response.data);
   }
 );
 

--- a/src/components/ForgotPassword/Form.js
+++ b/src/components/ForgotPassword/Form.js
@@ -3,38 +3,30 @@ import { useForm } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { object, string } from 'yup';
 
-import Form from 'components/Form';
 import AuthService from 'api/AuthService';
+import Form from 'components/Form';
+import { handleErrors } from 'helpers/errors';
 
 import styles from './ForgotPassword.module.scss';
 
-const defaultValues = {
-  email: '',
-};
-
 const ForgotPasswordForm = () => {
-  const [isResponseSuccess, setIsResponseSuccess] = useState(false);
-  const [error, setError] = useState('');
   const intl = useIntl();
+  const [isResponseSuccess, setIsResponseSuccess] = useState(false);
 
   const validationSchema = object().shape({
     email: string()
-      .email(intl.messages['common.invalidEmail'])
-      .required(intl.messages['common.required']),
+      .required(intl.messages['common.required'])
+      .email(intl.messages['common.invalidEmail']),
   });
 
-  const formMethods = useForm({
-    validationSchema,
-    defaultValues,
-  });
+  const formMethods = useForm({ validationSchema });
 
   const onSubmit = async ({ email }) => {
-    setIsResponseSuccess(false);
     try {
       await AuthService.resetPassword(email);
       setIsResponseSuccess(true);
-    } catch ({ errors }) {
-      setError(errors?.[0]);
+    } catch (error) {
+      handleErrors(error, formMethods.setError);
     }
   };
 
@@ -49,7 +41,6 @@ const ForgotPasswordForm = () => {
       </p>
       <Form.Input className={styles.emailInput} name="email" type="email" />
       <Form.Button text={intl.messages['common.resetPassword']} />
-      {error && <p className={styles.error}>{error}</p>}
       {isResponseSuccess && (
         <p className={styles.success}>
           <FormattedMessage id="common.resetPasswordSuccess" />

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -2,31 +2,36 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormContext } from 'react-hook-form';
 
+import FormButton from './Button';
 import FormInput from './Input';
 import FormSelect from './Select';
-import FormButton from './Button';
 
-const Form = ({ onSubmit, children, formMethods, ...props }) => {
-  const { handleSubmit } = formMethods;
+import styles from './Form.module.scss';
+
+const Form = ({ children, formMethods, onSubmit, ...props }) => {
+  const { errors, handleSubmit } = formMethods;
 
   return (
     <FormContext {...formMethods}>
       <form {...props} onSubmit={handleSubmit(onSubmit)}>
         {children}
       </form>
+      {errors?.general && (
+        <p className={styles.error}>{errors.general.message}</p>
+      )}
     </FormContext>
   );
 };
 
 Form.displayName = 'CustomForm';
+Form.Button = FormButton;
 Form.Input = FormInput;
 Form.Select = FormSelect;
-Form.Button = FormButton;
 
 Form.propTypes = {
+  children: PropTypes.node.isRequired,
   formMethods: PropTypes.object.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  children: PropTypes.array.isRequired,
 };
 
 export default Form;

--- a/src/components/Navbar/Menu.js
+++ b/src/components/Navbar/Menu.js
@@ -10,10 +10,14 @@ import styles from './Menu.module.scss';
 const Menu = ({ isAuthenticated, redirectTo }) => {
   const dispatch = useDispatch();
 
-  const handleSignOut = () => {
-    dispatch(signOut()).catch(({ errors }) => {
-      alert(errors);
-    });
+  const handleSignOut = async () => {
+    try {
+      await dispatch(signOut());
+    } catch ({ errors }) {
+      if (errors?.length) {
+        alert(errors[0]);
+      }
+    }
   };
 
   return (

--- a/src/components/Settings/ChangePasswordForm.js
+++ b/src/components/Settings/ChangePasswordForm.js
@@ -3,37 +3,28 @@ import { useForm } from 'react-hook-form';
 import { object, string } from 'yup';
 import { useIntl, FormattedMessage } from 'react-intl';
 
-import Form from 'components/Form';
 import AuthService from 'api/AuthService';
+import Form from 'components/Form';
+import { handleErrors } from 'helpers/errors';
 
 import styles from './Settings.module.scss';
-
-const defaultValues = {
-  password: '',
-};
-
-const validationSchema = object().shape({
-  password: string().required('Required'),
-});
 
 const ChangePasswordForm = () => {
   const intl = useIntl();
   const [isResponseSuccess, setIsResponseSuccess] = useState(false);
 
-  const { setError, ...formMethods } = useForm({
-    validationSchema,
-    defaultValues,
+  const validationSchema = object().shape({
+    password: string().required(intl.messages['common.required']),
   });
+
+  const formMethods = useForm({ validationSchema });
 
   const onSubmit = async ({ password }) => {
     try {
       await AuthService.updatePassword(password);
       setIsResponseSuccess(true);
-    } catch ({ errors: error, attributesErrors }) {
-      if (attributesErrors) {
-        setError('password', 'custom', attributesErrors?.password[0]);
-      }
-      if (error?.length > 0) setError('general', 'custom', error[0]);
+    } catch (error) {
+      handleErrors(error, formMethods.setError);
     }
   };
 
@@ -54,9 +45,6 @@ const ChangePasswordForm = () => {
         className={styles.button}
         text={intl.messages['common.updatePassword']}
       />
-      {formMethods.errors?.general && (
-        <p className={styles.error}>{formMethods.errors.general.message}</p>
-      )}
       {isResponseSuccess && (
         <p className={styles.success}>
           <FormattedMessage id="common.changePasswordSuccess" />

--- a/src/components/Settings/Form.js
+++ b/src/components/Settings/Form.js
@@ -5,22 +5,17 @@ import { object, string } from 'yup';
 import { useIntl, FormattedMessage } from 'react-intl';
 
 import Form from 'components/Form';
+import { handleErrors } from 'helpers/errors';
 import { useAuthentication } from 'hooks/auth';
 import { updateUser } from 'actions/auth';
 
 import styles from './Settings.module.scss';
 
-const validationSchema = object().shape({
-  firstName: string().required('Required'),
-  lastName: string().required('Required'),
-  locale: string().nullable().required('Required'),
-});
-
 const SettingsForm = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const [isResponseSuccess, setIsResponseSuccess] = useState(false);
   const { user } = useAuthentication();
+  const [isResponseSuccess, setIsResponseSuccess] = useState(false);
 
   const defaultValues = {
     firstName: user.firstName,
@@ -28,19 +23,20 @@ const SettingsForm = () => {
     locale: user.locale,
   };
 
-  const { setError, ...formMethods } = useForm({
-    validationSchema,
-    defaultValues,
+  const validationSchema = object().shape({
+    firstName: string().required(intl.messages['common.required']),
+    lastName: string().required(intl.messages['common.required']),
+    locale: string().nullable().required(intl.messages['common.required']),
   });
+
+  const formMethods = useForm({ defaultValues, validationSchema });
 
   const onSubmit = async (attributes) => {
     try {
       await dispatch(updateUser(attributes));
       setIsResponseSuccess(true);
-    } catch ({ errors: error }) {
-      if (error?.length > 0) {
-        setError('general', 'custom', error[0]);
-      }
+    } catch (error) {
+      handleErrors(error, formMethods.setError);
     }
   };
 
@@ -65,9 +61,6 @@ const SettingsForm = () => {
         className={styles.button}
         text={intl.messages['common.updateSettings']}
       />
-      {formMethods.errors?.general && (
-        <p className={styles.error}>{formMethods.errors.general.message}</p>
-      )}
       {isResponseSuccess && (
         <p className={styles.success}>
           <FormattedMessage id="common.updateSettingsSuccess" />

--- a/src/components/Settings/Settings.test.js
+++ b/src/components/Settings/Settings.test.js
@@ -143,7 +143,7 @@ describe('Settings', () => {
     await waitFor(() => {
       expect(mockedRequest.isDone()).toBeTruthy();
       expect(
-        queryByText('is too short (minimum is 6 characters)')
+        queryByText('Is too short (minimum is 6 characters)')
       ).toBeInTheDocument();
     });
   });

--- a/src/components/SignIn/Form.js
+++ b/src/components/SignIn/Form.js
@@ -1,20 +1,15 @@
-import React, { useState } from 'react';
-import { useIntl, FormattedMessage } from 'react-intl';
+import React from 'react';
+import { useIntl } from 'react-intl';
 import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 import { object, string } from 'yup';
 
 import { signIn } from 'actions/auth';
 import Form from 'components/Form';
-
-const defaultValues = {
-  email: '',
-  password: '',
-};
+import { handleErrors } from 'helpers/errors';
 
 const SignInForm = () => {
   const dispatch = useDispatch();
-  const [hasErrors, setHasErrors] = useState(false);
   const intl = useIntl();
 
   const validationSchema = object().shape({
@@ -24,16 +19,13 @@ const SignInForm = () => {
     password: string().required(intl.messages['common.required']),
   });
 
-  const formMethods = useForm({
-    validationSchema,
-    defaultValues,
-  });
+  const formMethods = useForm({ validationSchema });
 
   const onSubmit = async (values) => {
     try {
       await dispatch(signIn(values));
     } catch (error) {
-      setHasErrors(true);
+      handleErrors(error, formMethods.setError);
     }
   };
 
@@ -55,11 +47,6 @@ const SignInForm = () => {
         data-testid="submit-button"
         text={intl.messages['common.signIn']}
       />
-      {hasErrors && (
-        <p>
-          <FormattedMessage id="common.errorMessage" />
-        </p>
-      )}
     </Form>
   );
 };

--- a/src/components/SignIn/SignIn.test.js
+++ b/src/components/SignIn/SignIn.test.js
@@ -53,7 +53,7 @@ describe('SignIn', () => {
 
     await waitFor(() => {
       expect(mockedRequest.isDone()).toBeTruthy();
-      expect(queryByText('There was an error')).toBeInTheDocument();
+      expect(queryByText('The credentials are not valid')).toBeInTheDocument();
     });
   });
 

--- a/src/components/SignUp/Form.js
+++ b/src/components/SignUp/Form.js
@@ -1,45 +1,35 @@
-import React, { useState } from 'react';
-import { useIntl, FormattedMessage } from 'react-intl';
+import React from 'react';
+import { useIntl } from 'react-intl';
 import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 import { object, string } from 'yup';
 
 import { signUp } from 'actions/auth';
 import Form from 'components/Form';
-
-const defaultValues = {
-  email: '',
-  firstName: '',
-  lastName: '',
-  password: '',
-};
+import { handleErrors } from 'helpers/errors';
 
 const SignUpForm = () => {
   const dispatch = useDispatch();
-  const [hasError, setHasError] = useState(false);
   const intl = useIntl();
 
   const validationSchema = object().shape({
     email: string()
-      .email(intl.messages['common.invalidEmail'])
-      .required(intl.messages['common.required']),
+      .required(intl.messages['common.required'])
+      .email(intl.messages['common.invalidEmail']),
     firstName: string().required(intl.messages['common.required']),
     lastName: string().required(intl.messages['common.required']),
     password: string()
-      .min(8, intl.messages['common.shortPassword'])
-      .required(intl.messages['common.required']),
+      .required(intl.messages['common.required'])
+      .min(8, intl.messages['common.shortPassword']),
   });
 
-  const formMethods = useForm({
-    validationSchema,
-    defaultValues,
-  });
+  const formMethods = useForm({ validationSchema });
 
   const onSubmit = async (values) => {
     try {
       await dispatch(signUp({ locale: intl.locale, ...values }));
     } catch (error) {
-      setHasError(true);
+      handleErrors(error, formMethods.setError);
     }
   };
 
@@ -61,7 +51,6 @@ const SignUpForm = () => {
         data-testid="submit-button"
         text={intl.messages['common.signUp']}
       />
-      {hasError && <FormattedMessage id="common.errorMessage" />}
     </Form>
   );
 };

--- a/src/components/SignUp/SignUp.test.js
+++ b/src/components/SignUp/SignUp.test.js
@@ -65,7 +65,7 @@ describe('SignUp', () => {
 
     await waitFor(() => {
       expect(mockedRequest.isDone()).toBeTruthy();
-      expect(queryByText('There was an error')).toBeInTheDocument();
+      expect(queryByText('Has already been taken')).toBeInTheDocument();
     });
   });
 

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -1,0 +1,16 @@
+import { capitalize } from './string';
+
+export function handleErrors({ attributesErrors, errors }, setError) {
+  if (errors?.length) {
+    setError('general', 'custom', errors[0]);
+  }
+
+  if (attributesErrors && Object.keys(attributesErrors).length) {
+    setError(
+      Object.keys(attributesErrors).map((fieldName) => ({
+        message: capitalize(attributesErrors[fieldName][0]),
+        name: fieldName,
+      }))
+    );
+  }
+}

--- a/src/helpers/string.js
+++ b/src/helpers/string.js
@@ -1,0 +1,3 @@
+export function capitalize(string) {
+  return string.replace(/^\w/, (firstLetter) => firstLetter.toUpperCase());
+}

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -7,7 +7,7 @@ import { ActionType } from 'redux-promise-middleware';
 import Types from 'actions/types';
 import createReducer from 'reducers/createReducer';
 
-const { Fulfilled, Pending } = ActionType;
+const { Fulfilled, Rejected } = ActionType;
 
 const initialState = {
   user: null,
@@ -38,7 +38,8 @@ const handlers = {
   [Types.CLEAR_SESSION]: clearSession,
   [Types.SET_GUEST_LOCALE]: setGuestLocale,
   [`${Types.SIGN_IN}_${Fulfilled}`]: updateUser,
-  [`${Types.SIGN_OUT}_${Pending}`]: clearSession,
+  [`${Types.SIGN_OUT}_${Fulfilled}`]: clearSession,
+  [`${Types.SIGN_OUT}_${Rejected}`]: clearSession,
   [`${Types.SIGN_UP}_${Fulfilled}`]: updateUser,
   [`${Types.UPDATE_USER}_${Fulfilled}`]: updateUser,
 };

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -25,7 +25,7 @@ export const mockSignUpSuccess = (user) =>
 export const mockSignUpFailure = (user) =>
   baseMock.post('/users', humps.decamelizeKeys({ user })).reply(422, {
     attributes_errors: {
-      email: 'has already been taken',
+      email: ['has already been taken'],
     },
   });
 


### PR DESCRIPTION
#### :page_facing_up: Description:

The main task was moving general errors to the Form component to reduce the repetition.

---

#### :pushpin: Notes:

We may send the user locale as a header in each request or something like this in order to receive the error messages in the correct language.

---

#### :heavy_check_mark: Tasks:

* Add missing internationalization in error messages.
* Fix sign-out flow (the localStorage was cleaned before sending the request).
* Fix httpClient to use promise reject instead of throwing literals.
* Remove unnecessary default values.
* Move general errors to the Form component.
* Add attribute errors handling for each field.

---

#### :play_or_pause_button: Demo:
https://www.loom.com/share/5f3663374ffe4a77921a37581e3feb0b

@loopstudio/react-devs
