### PR TITLE
Use client side navigation on Logo.js

### DIFF
--- a/src/components/Navbar/Logo.js
+++ b/src/components/Navbar/Logo.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import styles from './Logo.module.scss';
 
@@ -6,9 +7,9 @@ const PRODUCT_NAME = 'LoopStudio';
 
 const Logo = () => (
   <div className={styles.logo}>
-    <a href="/" className={styles.brand}>
+    <Link to="/" className={styles.brand}>
       {PRODUCT_NAME}
-    </a>
+    </Link>
   </div>
 );
 


### PR DESCRIPTION
#### :page_facing_up: Description:

Use react-navigation Link on Logo.js in order to prevent app reloads.
That helps us with two tings:
Avoid reloading the whole app when Logo is clicked. 
Makes Lazy loaded pages to be requested just once.

---

#### :pushpin: Notes:

* Include TODOS, warnings, things other developers need to be aware of when merging, etc.

---

#### :heavy_check_mark: Tasks:

* Write the list of things you performed to help the reviewer.

---

#### :play_or_pause_button: Demo:
Before:
![Before](https://user-images.githubusercontent.com/29029506/84964543-c4daea00-b0e2-11ea-8d43-0f1149c2a1a6.gif)

After:
![After](https://user-images.githubusercontent.com/29029506/84964563-d2906f80-b0e2-11ea-97a9-b7b0fab96526.gif)


@loopstudio/react-devs
