### PR TITLE
Fix update user feature in Settings page

### DIFF
--- a/src/components/Settings/ChangePasswordForm.js
+++ b/src/components/Settings/ChangePasswordForm.js
@@ -21,7 +21,7 @@ const ChangePasswordForm = () => {
 
   const onSubmit = async ({ password }) => {
     try {
-      await AuthService.updatePassword(password);
+      await AuthService.updateUser({ password });
       setIsResponseSuccess(true);
     } catch (error) {
       handleErrors(error, formMethods.setError);

--- a/src/components/Settings/Settings.test.js
+++ b/src/components/Settings/Settings.test.js
@@ -5,8 +5,6 @@ import { fillInput, fireEvent, render, waitFor } from 'testUtils';
 import {
   mockUpdateUserSuccess,
   mockUpdateUserFailure,
-  mockUpdatePasswordSuccess,
-  mockUpdatePasswordFailure,
 } from 'testUtils/mocks/auth';
 import Settings from '.';
 
@@ -16,8 +14,13 @@ const fakeSettingsData = {
   locale: 'es',
 };
 
-const fakePassword = 'password';
-const fakeInvalidPassword = 'pass';
+const fakePasswordData = {
+  password: 'password',
+};
+
+const fakeInvalidPasswordData = {
+  password: 'pass',
+};
 
 const fakeState = {
   auth: {
@@ -106,7 +109,7 @@ describe('Settings', () => {
   });
 
   it('should submit new password correctly', async () => {
-    const mockedRequest = mockUpdatePasswordSuccess(fakePassword);
+    const mockedRequest = mockUpdateUserSuccess(fakePasswordData);
 
     const { getByTestId, queryByText } = render(<Settings />, {
       state: fakeState,
@@ -115,7 +118,7 @@ describe('Settings', () => {
     const password = getByTestId('password-input-settings');
     const submitButton = getByTestId('submit-password-button');
 
-    fillInput(password, fakePassword);
+    fillInput(password, fakePasswordData.password);
 
     fireEvent.click(submitButton);
 
@@ -128,7 +131,7 @@ describe('Settings', () => {
   });
 
   it('should show error on update password response failure', async () => {
-    const mockedRequest = mockUpdatePasswordFailure(fakeInvalidPassword);
+    const mockedRequest = mockUpdateUserFailure(fakeInvalidPasswordData);
 
     const { getByTestId, queryByText } = render(<Settings />, {
       state: fakeState,
@@ -136,15 +139,13 @@ describe('Settings', () => {
     const password = getByTestId('password-input-settings');
     const submitButton = getByTestId('submit-password-button');
 
-    fillInput(password, fakeInvalidPassword);
+    fillInput(password, fakeInvalidPasswordData.password);
 
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockedRequest.isDone()).toBeTruthy();
-      expect(
-        queryByText('Is too short (minimum is 6 characters)')
-      ).toBeInTheDocument();
+      expect(queryByText('Some scary error')).toBeInTheDocument();
     });
   });
 

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -17,10 +17,6 @@ class AuthService {
     return httpClient.post('/users/password', { email });
   }
 
-  static updatePassword(password) {
-    return httpClient.patch('/users/password', { password });
-  }
-
   static updateUser(user) {
     return httpClient.patch('/users', { user });
   }

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -60,19 +60,3 @@ export const mockUpdateUserFailure = (user) =>
     .reply(400, {
       errors: ['Some scary error'],
     });
-
-export const mockUpdatePasswordSuccess = (password) =>
-  baseMock
-    .patch('/users/password', decamelizeKeys({ password }))
-    .query({ locale: 'en' })
-    .reply(200, userResponse.data, userResponse.headers);
-
-export const mockUpdatePasswordFailure = (password) =>
-  baseMock
-    .patch('/users/password', decamelizeKeys({ password }))
-    .query({ locale: 'en' })
-    .reply(400, {
-      attributes_errors: {
-        password: ['is too short (minimum is 6 characters)'],
-      },
-    });


### PR DESCRIPTION
#### :page_facing_up: Description:

Fixes an elusive bug: Update password on settings was not working, since the endpoint we were using got repurposed for reset password feature. Instead, we are now calling update user for updating the password as well.

---

#### :heavy_check_mark: Tasks:

Calls `updateUser` for updating the password from the settings page

---

#### :play_or_pause_button: Demo:
🤷‍♀️ 
![image](https://user-images.githubusercontent.com/9577328/85158946-37f37600-b233-11ea-8ab7-d4ce326939a0.png)

@loopstudio/react-devs
