### PR TITLE
Allow user to change password on account settings

### DIFF
--- a/src/components/ForgotPassword/PasswordForm.js
+++ b/src/components/ForgotPassword/PasswordForm.js
@@ -31,7 +31,7 @@ const PasswordForm = ({ token }) => {
     validationSchema,
   });
 
-  const onSubmit = async ({ password, confirmPassword }) => {
+  const onSubmit = async ({ password }) => {
     setLoading(true);
 
     try {

--- a/src/components/Settings/ChangePasswordForm.js
+++ b/src/components/Settings/ChangePasswordForm.js
@@ -14,16 +14,21 @@ const ChangePasswordForm = () => {
   const [isResponseSuccess, setIsResponseSuccess] = useState(false);
 
   const validationSchema = object().shape({
-    password: string().required(intl.messages['common.required']),
+    password: string()
+      .required(intl.messages['common.required'])
+      .min(8, intl.messages['common.shortPassword']),
+    currentPassword: string().required(intl.messages['common.required']),
   });
 
   const formMethods = useForm({ validationSchema });
 
-  const onSubmit = async ({ password }) => {
+  const onSubmit = async ({ password, currentPassword }) => {
     try {
-      await AuthService.updateUser({ password });
+      await AuthService.updateUser({ password }, currentPassword);
       setIsResponseSuccess(true);
+      formMethods.setValue([{ password: '' }, { currentPassword: '' }]);
     } catch (error) {
+      setIsResponseSuccess(false);
       handleErrors(error, formMethods.setError);
     }
   };
@@ -34,6 +39,12 @@ const ChangePasswordForm = () => {
       className={styles.settingsForm}
       onSubmit={onSubmit}
     >
+      <Form.Input
+        label={intl.messages['common.currentPassword']}
+        name="currentPassword"
+        type="password"
+        data-testid="current-password-input-settings"
+      />
       <Form.Input
         label={intl.messages['common.newPassword']}
         name="password"

--- a/src/components/Settings/Settings.test.js
+++ b/src/components/Settings/Settings.test.js
@@ -15,11 +15,10 @@ const fakeSettingsData = {
 };
 
 const fakePasswordData = {
-  password: 'password',
-};
-
-const fakeInvalidPasswordData = {
-  password: 'pass',
+  user: {
+    password: 'password1234',
+  },
+  passwordCheck: 'oldPass',
 };
 
 const fakeState = {
@@ -43,7 +42,7 @@ const fakeState = {
 };
 
 describe('Settings', () => {
-  it('should submit account settings correctly', async () => {
+  it('confirms when account settings were changed successfully', async () => {
     const mockedRequest = mockUpdateUserSuccess(fakeSettingsData);
 
     const { getByTestId, queryByText } = render(<Settings />, {
@@ -69,7 +68,7 @@ describe('Settings', () => {
     });
   });
 
-  it('should show error on account settings response failure', async () => {
+  it('renders API errors when changing account settings', async () => {
     const mockedRequest = mockUpdateUserFailure(fakeSettingsData);
 
     const { getByTestId, queryByText } = render(<Settings />, {
@@ -92,7 +91,7 @@ describe('Settings', () => {
     });
   });
 
-  it('should show errors for invalid account settings values', async () => {
+  it('requires the first name when changing account settings', async () => {
     const { getByTestId, queryByText } = render(<Settings />, {
       state: fakeState,
     });
@@ -108,17 +107,22 @@ describe('Settings', () => {
     });
   });
 
-  it('should submit new password correctly', async () => {
-    const mockedRequest = mockUpdateUserSuccess(fakePasswordData);
+  it('confirms when the password was changed successfully', async () => {
+    const mockedRequest = mockUpdateUserSuccess(
+      fakePasswordData.user,
+      fakePasswordData.passwordCheck
+    );
 
     const { getByTestId, queryByText } = render(<Settings />, {
       state: fakeState,
     });
 
-    const password = getByTestId('password-input-settings');
+    const currentPasswordInput = getByTestId('current-password-input-settings');
+    const newPasswordInput = getByTestId('password-input-settings');
     const submitButton = getByTestId('submit-password-button');
 
-    fillInput(password, fakePasswordData.password);
+    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+    fillInput(newPasswordInput, fakePasswordData.user.password);
 
     fireEvent.click(submitButton);
 
@@ -130,16 +134,22 @@ describe('Settings', () => {
     });
   });
 
-  it('should show error on update password response failure', async () => {
-    const mockedRequest = mockUpdateUserFailure(fakeInvalidPasswordData);
+  it('renders API errors when changing the password', async () => {
+    const mockedRequest = mockUpdateUserFailure(
+      fakePasswordData.user,
+      fakePasswordData.passwordCheck
+    );
 
     const { getByTestId, queryByText } = render(<Settings />, {
       state: fakeState,
     });
-    const password = getByTestId('password-input-settings');
+
+    const currentPasswordInput = getByTestId('current-password-input-settings');
+    const newPasswordInput = getByTestId('password-input-settings');
     const submitButton = getByTestId('submit-password-button');
 
-    fillInput(password, fakeInvalidPasswordData.password);
+    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+    fillInput(newPasswordInput, fakePasswordData.user.password);
 
     fireEvent.click(submitButton);
 
@@ -149,19 +159,62 @@ describe('Settings', () => {
     });
   });
 
-  it('should show error for empty new password values', async () => {
+  it('requires a new password when changing the password', async () => {
     const { getByTestId, queryByText } = render(<Settings />, {
       state: fakeState,
     });
-    const password = getByTestId('password-input-settings');
+
+    const currentPasswordInput = getByTestId('current-password-input-settings');
+    const newPasswordInput = getByTestId('password-input-settings');
     const submitButton = getByTestId('submit-password-button');
 
-    fillInput(password, '');
+    fillInput(currentPasswordInput, '');
+    fillInput(newPasswordInput, fakePasswordData.user.password);
 
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(queryByText('Required')).toBeInTheDocument();
+    });
+  });
+
+  it('requires the new password when changing the password', async () => {
+    const { getByTestId, queryByText } = render(<Settings />, {
+      state: fakeState,
+    });
+
+    const currentPasswordInput = getByTestId('current-password-input-settings');
+    const newPasswordInput = getByTestId('password-input-settings');
+    const submitButton = getByTestId('submit-password-button');
+
+    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+    fillInput(newPasswordInput, '');
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(queryByText('Required')).toBeInTheDocument();
+    });
+  });
+
+  it('requires the current password to be at least 8 chars', async () => {
+    const { getByTestId, queryByText } = render(<Settings />, {
+      state: fakeState,
+    });
+
+    const currentPasswordInput = getByTestId('current-password-input-settings');
+    const newPasswordInput = getByTestId('password-input-settings');
+    const submitButton = getByTestId('submit-password-button');
+
+    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+    fillInput(newPasswordInput, 'pass');
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        queryByText('Password too short, minimum length is 8 characters')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/locales/messages/en-US.js
+++ b/src/locales/messages/en-US.js
@@ -6,6 +6,7 @@ export default {
     confirm: 'Submit',
     confirmPassword: 'Confirm password',
     createAccount: 'Create one here',
+    currentPassword: 'Current Password',
     dontHaveAccountQuestion: 'Don’t have an account?',
     email: 'Email',
     errorBoundaryMessage: 'An error occurred',

--- a/src/locales/messages/es-ES.js
+++ b/src/locales/messages/es-ES.js
@@ -6,6 +6,7 @@ export default {
     confirm: 'Confirmar',
     confirmPassword: 'Confirmar contraseña',
     createAccount: 'Crea una aquí',
+    currentPassword: 'Contraseña Actual',
     dontHaveAccountQuestion: '¿No tienes cuenta?',
     email: 'Correo',
     errorBoundaryMessage: 'Ha ocurrido un error',

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -24,7 +24,7 @@ const setGuestLocale = (draftState, payload) => {
   draftState.guestLocale = payload.locale;
 };
 
-const updateUser = (draftState, payload) => {
+const setUser = (draftState, payload) => {
   const {
     headers: { accessToken, client, uid },
     data,
@@ -34,14 +34,18 @@ const updateUser = (draftState, payload) => {
   draftState.user = data.user;
 };
 
+const updateUser = (draftState, payload) => {
+  draftState.user = payload.data.user;
+};
+
 const handlers = {
   [Types.CLEAR_SESSION]: clearSession,
-  [`${Types.RESET_PASSWORD}_${Fulfilled}`]: updateUser,
+  [`${Types.RESET_PASSWORD}_${Fulfilled}`]: setUser,
   [Types.SET_GUEST_LOCALE]: setGuestLocale,
-  [`${Types.SIGN_IN}_${Fulfilled}`]: updateUser,
+  [`${Types.SIGN_IN}_${Fulfilled}`]: setUser,
   [`${Types.SIGN_OUT}_${Fulfilled}`]: clearSession,
   [`${Types.SIGN_OUT}_${Rejected}`]: clearSession,
-  [`${Types.SIGN_UP}_${Fulfilled}`]: updateUser,
+  [`${Types.SIGN_UP}_${Fulfilled}`]: setUser,
   [`${Types.UPDATE_USER}_${Fulfilled}`]: updateUser,
 };
 

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -17,12 +17,12 @@ class AuthService {
     return httpClient.post('/users/password', { email });
   }
 
-  static updateUser(user) {
-    return httpClient.patch('/users', { user });
+  static updateUser(user, passwordCheck) {
+    return httpClient.patch('/user', { user, passwordCheck });
   }
 
-  static verifyToken(token) {
-    return httpClient.get(`users/password/edit?reset_password_token=${token}`);
+  static verifyToken(resetPasswordToken) {
+    return httpClient.get('users/password/edit', { resetPasswordToken });
   }
 
   static resetPassword(password, resetPasswordToken) {

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -47,16 +47,22 @@ export const mockSignInFailure = (credentials) =>
       errors: ['The credentials are not valid'],
     });
 
-export const mockUpdateUserSuccess = (user) =>
-  baseMock
-    .patch('/users', decamelizeKeys({ user }))
-    .query(true)
-    .reply(200, userResponse.data, userResponse.headers);
+export const mockUpdateUserSuccess = (user, passwordCheck) => {
+  const body = passwordCheck ? { user, passwordCheck } : { user };
 
-export const mockUpdateUserFailure = (user) =>
-  baseMock
-    .patch('/users', decamelizeKeys({ user }))
+  return baseMock
+    .patch('/user', decamelizeKeys(body))
+    .query(true)
+    .reply(200, userResponse.data);
+};
+
+export const mockUpdateUserFailure = (user, passwordCheck) => {
+  const body = passwordCheck ? { user, passwordCheck } : { user };
+
+  return baseMock
+    .patch('/user', decamelizeKeys(body))
     .query({ locale: 'en' })
     .reply(400, {
       errors: ['Some scary error'],
     });
+};


### PR DESCRIPTION
### :page_facing_up: Description:

Reset password feature when being logged in was not previously working (API endpoint did not permit the param password, ignoring the new password provided). This PR fixes the feature (API needs params in a different way) and also fixes some routes that were slightly changed in the backed. EG. to edit the user profile the route was previously `PUT /users` now becomes `PUT /user`. 

---

#### :heavy_check_mark: Tasks:

* Fixes routes to match the new API routes
* Adds new password check input on the change password form
* Adds validation for new password to be at least 8 chars long (same as in signup)
* Clears fields after submitting the form successfully
* In the reducer for auth, after updating the user profile, don't override the credentials with the response headers because they don't actually come from the backend response 


Test changes: 

* Fixes tests to match the changes
* Adds tests to check min 8 chars in password and that old password check is required
* Renames the tests descriptions to be more readable 

Other unrelated change: 
* Remove password confirmation from PasswordForm since we are not currently doing anything with it in the method
* Use axios way in AuthService to pass the query params (suggested by @donatoaguirre24 )
* Fixes bug in change password form were the error was not being set and the second time you changed the password you would keep seeing the green confirmation message plus the red message

---

#### :play_or_pause_button: Demo:
https://www.loom.com/share/1d398469625a4c67b6a94b092b7b9160

@loopstudio/react-devs

PS. Thank you @donatoaguirre24 for the tips