### PR TITLE
Update error boundary to use getDerivedStateFromErrors

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -13,8 +13,8 @@ class ErrorBoundary extends React.Component {
     };
   }
 
-  componentDidCatch(error) {
-    this.setState({ hasError: true, error });
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
   }
 
   render() {


### PR DESCRIPTION
#### :page_facing_up: Description:

Update error boundary to use `getDerivedStateFromErrors` instead of `componentDidCatch`.

Currently we are using the `componentDidCatch` method just to update the state of the ErrorBoundary, so it's better to use the `getDerivedStateFromErrors` for this. The reason for this is that the `componentDidCatch` method gets executed after the commit phase of the fallback while, with these new changes, the state will get updated at the render phase of it.

---

#### :heavy_check_mark: Tasks:

* Just change the error boundary event for error handling

---

@loopstudio/react-devs
