### PR TITLE
Adds test to the app routing

### DIFF
--- a/src/components/AuthenticatedApp/AuthenticatedApp.test.js
+++ b/src/components/AuthenticatedApp/AuthenticatedApp.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { renderWithRouter } from 'testUtils';
+import { userData, authenticationHeaders } from 'testUtils/mocks/auth';
+import AuthenticatedApp from './AuthenticatedApp';
+
+const state = {
+  auth: {
+    user: userData,
+    session: authenticationHeaders,
+  },
+};
+
+describe('Authenticated App', () => {
+  it('renders the Home Page', () => {
+    const { getByText } = renderWithRouter(<AuthenticatedApp />, {
+      state,
+      history: ['/'],
+    });
+
+    expect(getByText('Hello World')).toBeInTheDocument();
+  });
+
+  it('renders the Settings Page', () => {
+    const { getByText } = renderWithRouter(<AuthenticatedApp />, {
+      state,
+      history: ['/settings'],
+    });
+
+    expect(getByText('Account settings')).toBeInTheDocument();
+  });
+
+  it('renders the No match Page', () => {
+    const { getByText } = renderWithRouter(<AuthenticatedApp />, {
+      state,
+      history: ['/no-match'],
+    });
+
+    expect(getByText('404')).toBeInTheDocument();
+  });
+});

--- a/src/components/NoMatch/NoMatch.test.js
+++ b/src/components/NoMatch/NoMatch.test.js
@@ -7,7 +7,7 @@ import NoMatch from '.';
 describe('NoMatch', () => {
   test('shows a "404" message', () => {
     const { queryByText } = renderWithRouter(<NoMatch />, {
-      route: '/non-existent-route',
+      history: ['/non-existent-route'],
     });
 
     expect(queryByText('404')).toBeInTheDocument();

--- a/src/components/SignIn/SignIn.test.js
+++ b/src/components/SignIn/SignIn.test.js
@@ -21,7 +21,7 @@ describe('SignIn', () => {
     const mockedRequest = mockSignInSuccess(fakeCredentials);
 
     const { getByTestId, history } = renderWithRouter(<SignIn />, {
-      route: '/sign-in',
+      history: ['/sign-in'],
     });
     const submitButton = getByTestId('submit-button');
     const email = getByTestId('email-input');

--- a/src/components/SignUp/SignUp.test.js
+++ b/src/components/SignUp/SignUp.test.js
@@ -24,7 +24,7 @@ describe('SignUp', () => {
     const mockedRequest = mockSignUpSuccess(fakeUser);
 
     const { getByTestId, history } = renderWithRouter(<SignUp />, {
-      route: '/sign-up',
+      history: ['/sign-up'],
     });
 
     const email = getByTestId('email-input');

--- a/src/components/UnauthenticatedApp/UnauthenticatedApp.test.js
+++ b/src/components/UnauthenticatedApp/UnauthenticatedApp.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { renderWithRouter } from 'testUtils';
+import UnauthenticatedApp from './UnauthenticatedApp';
+
+describe('Unauthenticated App', () => {
+  it('renders the Sign in Page', () => {
+    const { getByTestId } = renderWithRouter(<UnauthenticatedApp />, {
+      history: ['/sign-in'],
+    });
+
+    expect(getByTestId('signin-form')).toBeInTheDocument();
+  });
+
+  it('renders the Sign up Page', () => {
+    const { getByTestId } = renderWithRouter(<UnauthenticatedApp />, {
+      history: ['/sign-up'],
+    });
+
+    expect(getByTestId('signup-form')).toBeInTheDocument();
+  });
+
+  it('renders the Forgot Password Page', () => {
+    const { getByTestId } = renderWithRouter(<UnauthenticatedApp />, {
+      history: ['/forgot-password'],
+    });
+
+    expect(getByTestId('forgot-password-email-form')).toBeInTheDocument();
+  });
+
+  it('redirects to the Sign in Page when an unknown route is used', () => {
+    const { getByTestId } = renderWithRouter(<UnauthenticatedApp />, {
+      history: ['/no-match'],
+    });
+
+    expect(getByTestId('signin-form')).toBeInTheDocument();
+  });
+});

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -3,7 +3,7 @@ import flatten from 'flat';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { ThemeProvider } from 'emotion-theming';
@@ -13,7 +13,10 @@ import AppLocale from 'locales';
 import configureStore from 'store';
 import httpClient, { applyMiddlewares } from 'services/httpClient';
 
-const renderWithProviders = (ui, { state = {}, ...options } = {}) => {
+const renderWithProviders = (
+  ui,
+  { state = {}, history = ['/'], ...options } = {}
+) => {
   const { store } = configureStore({ initialState: state, persist: false });
   applyMiddlewares(httpClient, store);
 
@@ -21,7 +24,7 @@ const renderWithProviders = (ui, { state = {}, ...options } = {}) => {
     <Provider store={store}>
       <IntlProvider locale="en" messages={flatten(AppLocale.en.messages)}>
         <ThemeProvider theme={theme}>
-          <BrowserRouter>{children}</BrowserRouter>
+          <MemoryRouter initialEntries={history}>{children}</MemoryRouter>
         </ThemeProvider>
       </IntlProvider>
     </Provider>
@@ -35,7 +38,7 @@ const renderWithProviders = (ui, { state = {}, ...options } = {}) => {
 };
 
 function renderWithRouter(ui, options) {
-  const history = createMemoryHistory({ initialEntries: [options.route] });
+  const history = createMemoryHistory({ initialEntries: options.history });
   return {
     ...renderWithProviders(ui, options),
     history,

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -1,20 +1,24 @@
 import { decamelizeKeys } from 'helpers/decamelize';
 import baseMock from './base';
 
+export const userData = {
+  id: 1,
+  first_name: 'User',
+  last_name: 'Example',
+  email: 'user@example.com',
+};
+
+export const authenticationHeaders = {
+  'Access-Token': 'token',
+  Uid: 'user@example.com',
+  Client: 'client',
+};
+
 const userResponse = {
   data: {
-    user: {
-      id: 1,
-      first_name: 'User',
-      last_name: 'Example',
-      email: 'user@example.com',
-    },
+    user: userData,
   },
-  headers: {
-    'Access-Token': 'token',
-    Uid: 'user@example.com',
-    Client: 'client',
-  },
+  headers: authenticationHeaders,
 };
 
 export const mockSignUpSuccess = (user) =>


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR adds test to the `AuthenticatedApp` and `UnauthenticatedApp` component.

---

#### :pushpin: Notes:

To archive the goal of this PR I had to change the way we implement the Router on the `renderWithProviders` function as well as on the `renderWithRouter` one in order to be able to manipulate the routes of the app when testing.

The reason for this is explained on the behavior of the component we were using ([BrowserRouter](https://reactrouter.com/web/api/BrowserRouterv)) vs the one it has been changed for ([MemoryRouter](https://reactrouter.com/web/api/MemoryRouter))

---

#### :heavy_check_mark: Tasks:

- Change the Router we use on the `renderWithProviders` function.
- Minor adjustments to the tests that use the `renderWithRouter` function.
- Adds the AuthenticatedApp component tests.
- Adds the UnauthenticatedApp component tests.

@loopstudio/react-devs
