### PR TITLE
Fixes routes test to use history

### DIFF
--- a/src/components/SignIn/SignIn.test.js
+++ b/src/components/SignIn/SignIn.test.js
@@ -34,7 +34,7 @@ describe('SignIn', () => {
 
     await waitFor(() => {
       expect(mockedRequest.isDone()).toBeTruthy();
-      expect(history.location.pathname).toMatch('/');
+      expect(history.location.pathname).toBe('/');
     });
   });
 

--- a/src/components/SignUp/SignUp.test.js
+++ b/src/components/SignUp/SignUp.test.js
@@ -42,7 +42,7 @@ describe('SignUp', () => {
 
     await waitFor(() => {
       expect(mockedRequest.isDone()).toBeTruthy();
-      expect(history.location.pathname).toMatch('/');
+      expect(history.location.pathname).toBe('/');
     });
   });
 

--- a/src/components/UnauthenticatedApp/UnauthenticatedApp.test.js
+++ b/src/components/UnauthenticatedApp/UnauthenticatedApp.test.js
@@ -30,10 +30,10 @@ describe('Unauthenticated App', () => {
   });
 
   it('redirects to the Sign in Page when an unknown route is used', () => {
-    const { getByTestId } = renderWithRouter(<UnauthenticatedApp />, {
+    const { history } = renderWithRouter(<UnauthenticatedApp />, {
       history: ['/no-match'],
     });
 
-    expect(getByTestId('signin-form')).toBeInTheDocument();
+    expect(history.location.pathname).toBe('/sign-in');
   });
 });

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -3,7 +3,7 @@ import flatten from 'flat';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { ThemeProvider } from 'emotion-theming';
@@ -15,7 +15,7 @@ import httpClient, { applyMiddlewares } from 'services/httpClient';
 
 const renderWithProviders = (
   ui,
-  { state = {}, history = ['/'], ...options } = {}
+  { state = {}, history = createMemoryHistory(), ...options } = {}
 ) => {
   const { store } = configureStore({ initialState: state, persist: false });
   applyMiddlewares(httpClient, store);
@@ -24,7 +24,7 @@ const renderWithProviders = (
     <Provider store={store}>
       <IntlProvider locale="en" messages={flatten(AppLocale.en.messages)}>
         <ThemeProvider theme={theme}>
-          <MemoryRouter initialEntries={history}>{children}</MemoryRouter>
+          <Router history={history}>{children}</Router>
         </ThemeProvider>
       </IntlProvider>
     </Provider>
@@ -37,11 +37,12 @@ const renderWithProviders = (
   return render(ui, { wrapper: Wrapper, ...options });
 };
 
-function renderWithRouter(ui, options) {
-  const history = createMemoryHistory({ initialEntries: options.history });
+function renderWithRouter(ui, { history, ...options }) {
+  const historyData = createMemoryHistory({ initialEntries: history });
+
   return {
-    ...renderWithProviders(ui, options),
-    history,
+    ...renderWithProviders(ui, { history: historyData, ...options }),
+    history: historyData,
   };
 }
 


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR improves the quality of some tests.

---

#### :pushpin: Notes:

This PR once again changes the Router on the `renderWithProviders` function to use a Router instead of a MemoryRouter. The reason behind this is that the Router Component receive a history object instead of an array of routes like the MemoryRouter. The advantage of this is that now, when we use `renderWithRouter` we can actually use, on the router, the history object that function returns. This allows us to see the changes that a component (Like the sign in form) does to the history on our test given that the history object that we have is the same as the one the component is manipulating.

---

#### :heavy_check_mark: Tasks:

- Replaces MemoryRouter with Router.
- Fixes a couple of "broken" tests.

@loopstudio/react-devs
