### PR TITLE
Avoid showing an alert when the logout request fails due to a invalid token

### DIFF
--- a/src/components/Navbar/Menu.js
+++ b/src/components/Navbar/Menu.js
@@ -17,9 +17,7 @@ const Menu = ({ isAuthenticated }) => {
       await dispatch(signOut());
       history.replace('/sign-in');
     } catch ({ errors }) {
-      if (errors?.length) {
-        alert(errors[0]);
-      }
+      console.error(errors);
     }
   };
 


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR addresses the case when there is an invalid auth token and you try to logout. Instead of showing an alert message and logging out the user we just log the him out.

---

#### :heavy_check_mark: Tasks:

* Remove the alert and just print an error in the console to log it

---

#### :play_or_pause_button: Demo:
This was the thing that was happening before this change:
https://www.loom.com/share/aef73ec3875e4b03b0c799f49e62c84c

@loopstudio/react-devs
