### PR TITLE
Add tabIndex to sign in form to email and password fields

### DIFF
--- a/src/components/SignIn/Form.js
+++ b/src/components/SignIn/Form.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/tabindex-no-positive */
 import React, { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers';
 import { useForm } from 'react-hook-form';
@@ -39,20 +40,26 @@ const SignInForm = () => {
   return (
     <Form
       data-testid="signin-form"
-      onSubmit={onSubmit}
       formMethods={formMethods}
+      onSubmit={onSubmit}
     >
-      <Form.Input name="email" type="email" data-testid="email-input" />
       <Form.Input
-        name="password"
-        type="password"
+        data-testid="email-input"
+        name="email"
+        tabIndex="1"
+        type="email"
+      />
+      <Form.Input
+        data-testid="password-input"
         helpLinkPath="/forgot-password"
         helpMessage={intl.messages['common.forgotPassword']}
-        data-testid="password-input"
+        name="password"
+        tabIndex="2"
+        type="password"
       />
       <Form.Button
-        isLoading={isLoading}
         data-testid="submit-button"
+        isLoading={isLoading}
         text={intl.messages['common.signIn']}
       />
     </Form>


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR fixes the issue of the navigation in the login page by adding the `tabIndex` property to the `email` and `password` inputs 

---

#### :play_or_pause_button: Demo:
https://www.loom.com/share/f3b79a728e8e4e11bf89eeaad76974d9

@loopstudio/react-devs
