### PR TITLE
Remove default hardcoded avatar and use the one Gravatar provides instead

### DIFF
--- a/src/components/Navbar/UserOptions.js
+++ b/src/components/Navbar/UserOptions.js
@@ -14,16 +14,13 @@ import {
   MobileButton,
 } from 'components/Navbar/NavBar.styles';
 
-const AVATAR_PLACEHOLDER = 'https://i.pravatar.cc/150?img=41';
-
 const RightItem = () => {
   const user = useUser();
   const history = useHistory();
   const isAuthenticated = useAuthentication();
   const [navOpen, setNavOpen] = useState(false);
   const emailHash = md5(user?.email || '');
-  const defaultAvatar = encodeURIComponent(AVATAR_PLACEHOLDER);
-  const gravatarURL = `https://www.gravatar.com/avatar/${emailHash}?default=${defaultAvatar}`;
+  const gravatarURL = `https://www.gravatar.com/avatar/${emailHash}`;
 
   const handleRedirectTo = (path) => history.push(path);
 


### PR DESCRIPTION
#### :page_facing_up: Description:

The previous avatar placeholder we were using was timing out most of the times. So this PR switches the default avatar to the one Gravatar provides.

#### :play_or_pause_button: Demo:
![image](https://user-images.githubusercontent.com/15303963/95113860-77c66680-0719-11eb-9101-87b6bbb90e5f.png)


@loopstudio/react-devs
