### PR TITLE
Ignore serviceWorker file for tests

### DIFF
--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 // This optional code is used to register a service worker.
 // register() is not called by default.
 


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR ignores the `serviceWorker.js` file so that it doesn't lower our test coverage.

---

#### :heavy_check_mark: Tasks:

* Add `/* istanbul ignore file */` to serviceWorker.js

---

#### :play_or_pause_button: Demo:

Test coverage: 

Before:

![image](https://user-images.githubusercontent.com/60147387/96499632-0c55bc00-1224-11eb-95ac-a7438003076a.png)

After:

![image](https://user-images.githubusercontent.com/60147387/96499668-18417e00-1224-11eb-88ae-cee533ac4103.png)


@loopstudio/react-devs
