### PR TITLE
Fixes error handling issues

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.test.js
+++ b/src/components/ForgotPassword/ForgotPassword.test.js
@@ -148,7 +148,9 @@ describe('ForgotPassword', () => {
 
     await waitFor(() => {
       expect(mockVerifyToken.isDone()).toBeTruthy();
-      expect(getByText('Invalid token')).toBeInTheDocument();
+      expect(
+        getByText('the reset password token is invalid')
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/components/ForgotPassword/ForgotPassword.test.js
+++ b/src/components/ForgotPassword/ForgotPassword.test.js
@@ -149,7 +149,7 @@ describe('ForgotPassword', () => {
     await waitFor(() => {
       expect(mockVerifyToken.isDone()).toBeTruthy();
       expect(
-        getByText('the reset password token is invalid')
+        getByText('The reset password token is invalid')
       ).toBeInTheDocument();
     });
   });

--- a/src/components/ForgotPassword/TokenForm.js
+++ b/src/components/ForgotPassword/TokenForm.js
@@ -22,7 +22,7 @@ const TokenForm = ({ onStepChange, onSaveToken }) => {
   const intl = useIntl();
 
   const validationSchema = object().shape({
-    token: string(intl.messages['common.invalidToken'])
+    token: string()
       .length(6, intl.messages['common.lengthToken'])
       .required(intl.messages['common.required']),
   });
@@ -38,10 +38,7 @@ const TokenForm = ({ onStepChange, onSaveToken }) => {
       await AuthService.verifyToken(token);
       onSaveToken(token);
       onStepChange(RESET_PASSWORD_STEPS.updatePassword);
-    } catch ({ errors }) {
-      const error = errors?.[0] || {
-        errors: [intl.messages['common.invalidToken']],
-      };
+    } catch (error) {
       handleErrors(error, formMethods.setError);
       setLoading(false);
     }

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -2,7 +2,7 @@ import { capitalize } from 'helpers/string';
 
 export function handleErrors({ attributesErrors, errors }, setError) {
   if (errors?.length) {
-    setError('general', { message: errors[0] });
+    setError('general', { message: capitalize(errors[0]) });
   }
 
   if (attributesErrors && Object.keys(attributesErrors).length) {

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -6,13 +6,10 @@ export function handleErrors({ attributesErrors, errors }, setError) {
   }
 
   if (attributesErrors && Object.keys(attributesErrors).length) {
-    const filteredErrors = Object.keys(attributesErrors).filter(
-      (fieldName) => attributesErrors[fieldName].length
-    );
-    filteredErrors.forEach((fieldName) =>
+    Object.keys(attributesErrors).forEach((fieldName) => {
       setError(fieldName, {
         message: capitalize(attributesErrors[fieldName][0]),
-      })
-    );
+      });
+    });
   }
 }

--- a/src/locales/messages/en-US.js
+++ b/src/locales/messages/en-US.js
@@ -21,7 +21,6 @@ export default {
       'Step 1: Enter your email and we’ll help you reset your password',
     goBackHome: 'Go back home',
     invalidEmail: 'Invalid email',
-    invalidToken: 'Invalid token',
     lastName: 'Last Name',
     lengthToken: 'Must have six digits',
     locale: 'Language',

--- a/src/locales/messages/es-ES.js
+++ b/src/locales/messages/es-ES.js
@@ -21,7 +21,6 @@ export default {
       'Paso 1: Ingresa tu correo y te ayudaremos a recuperar tu contraseña',
     goBackHome: 'Volver al inicio',
     invalidEmail: 'Email inválido',
-    invalidToken: 'Código no válido',
     lastName: 'Apellido',
     lengthToken: 'Debe tener seis dígitos',
     locale: 'Idioma',

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -93,8 +93,8 @@ export const mockVerifyTokenFailure = (resetPasswordToken) =>
   baseMock
     .get('/users/password/edit')
     .query(decamelizeKeys({ locale: 'en', resetPasswordToken }))
-    .reply(404, {
-      errors: null,
+    .reply(400, {
+      errors: ['the reset password token is invalid'],
     });
 
 export const mockResetPasswordSuccess = (password, resetPasswordToken) =>


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR addresses implementation on the FE of some error handling issues noted on the BE a few months ago, which follow:

1 - El endpoint de resetPassword (PUT /users/password) esta devolviendo errores en los siguientes atributos posibles:
`password`
`reset_password_token`

Actualmente cuando actualizamos la contrasenia y los datos se ingresan correctamente, el endpoint funciona lo mas bien. Pero en el caso que se devuelve un error (por ejemplo, si la contrasenia tiene menos de 6 caracteres), el error viene con el cuerpo que se ve en la foto 1, con reset_password_token vacio. Esto hace que la app crashee, y por eso agregamos un guard manual que queremos eliminar porque no deberia estar.

![image](https://user-images.githubusercontent.com/9577328/96509339-3c0bc080-1232-11eb-9b58-f51e8f7dfbb7.png)

2 - Cuando hacemos una llamada a un endpoint que no existe, la respuesta del backend es la mostrada en la foto 2. Tambien es inconsistente con la forma en que devolvemos errores.

![image](https://user-images.githubusercontent.com/9577328/96509375-48901900-1232-11eb-8ade-d55adecf28cf.png)

**NOTA: este issue no parece haber sido arreglado en el Backend.**

3 - Cuando el token es invalido, se devuelve el error siguiente:

![image](https://user-images.githubusercontent.com/9577328/96509415-5d6cac80-1232-11eb-9d95-7f05acf791e6.png)

4 - Cuando le pasamos el codigo (token) que recibimos por email, si es incorrecto el response no viene con cuerpo de error (404)

![image](https://user-images.githubusercontent.com/9577328/96509457-6e1d2280-1232-11eb-9bb0-19a2f6edd910.png)

---

#### :play_or_pause_button: Demo:
https://www.loom.com/share/8ef8c93c78e7469d97e75a92e01d50d1?from_recorder=1

@loopstudio/react-devs
