### PR TITLE
feat: Coverage threshold CI blocker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - 'master'
@@ -37,3 +38,6 @@ jobs:
 
       - name: Run tests
         run: yarn test
+
+      - name: Run test coverage
+        run: yarn test:coverage

--- a/package.json
+++ b/package.json
@@ -8,10 +8,21 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
-    "test:coverage": "react-scripts test --env=jest-environment-jsdom-sixteen --coverage --watchAll=false",
+    "test:coverage": "react-scripts test --ci --env=jest-environment-jsdom-sixteen --coverage --watchAll=false",
     "lint": "eslint .",
     "eject": "react-scripts eject",
     "pre-push": "eslint ."
+  },
+  "jest": {
+    "coverageReporters": ["text-summary"],
+    "coverageThreshold": {
+      "global": {
+        "branches": 85,
+        "functions": 85,
+        "lines": 85,
+        "statements": 85
+      }
+    }
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
#### :page_facing_up: Description:

Featuring: @emmaielle 

Now Github will block a pull request if the coverage threshold is not met. We should agree on a percentage but for now I'll set it up at `85%` so it doesn't block current PRs.

What's great about this is that we can configure the thresholds on a granular basis:
```json
{
  ...
  "jest": {
    "coverageThreshold": {
      "global": {
        "branches": 50,
        "functions": 50,
        "lines": 50,
        "statements": 50
      },
      "./src/components/": {
        "branches": 40,
        "statements": 40
      },
      "./src/reducers/**/*.js": {
        "statements": 90
      },
      "./src/api/very-important-module.js": {
        "branches": 100,
        "functions": 100,
        "lines": 100,
        "statements": 100
      }
    }
  }
}
```

---
#### :play_or_pause_button: Demo:
<p align="center">
<img width="734" alt="Screen Shot 2020-12-15 at 18 17 44" src="https://user-images.githubusercontent.com/5625064/102273922-da9a6200-3f01-11eb-993e-b5b9dcd05ad0.png">
</p>
@loopstudio/react-devs
