### PR TITLE
Add UserOptions tests

### DIFF
--- a/src/features/app/components/Navbar/UserOptions.test.js
+++ b/src/features/app/components/Navbar/UserOptions.test.js
@@ -1,0 +1,45 @@
+import { fireEvent, render } from 'testUtils';
+
+import { userData, authenticationHeaders } from 'testUtils/mocks/auth';
+import UserOptions from 'features/app/components/Navbar/UserOptions';
+
+const state = {
+  auth: {
+    user: userData,
+    session: authenticationHeaders,
+  },
+};
+
+describe('UserOptions', () => {
+  it('renders an avatar when the user is logged in', () => {
+    const { getByRole } = render(<UserOptions />, { state });
+
+    getByRole('img', { name: 'avatar' });
+  });
+
+  it('does not render an avatar when the user is not logged in', () => {
+    const { queryByRole } = render(<UserOptions />);
+
+    expect(queryByRole('img', { name: 'avatar' })).toBeNull();
+  });
+
+  it('opens the menu if the user clicks on the avatar', () => {
+    const { getByRole } = render(<UserOptions />, { state });
+
+    const avatar = getByRole('button', { name: 'avatar' });
+
+    fireEvent.click(avatar);
+
+    getByRole('button', { name: 'Sign out' });
+  });
+
+  it('opens the menu when the user is not logged in and clicks on the menu button', () => {
+    const { getByRole } = render(<UserOptions />);
+
+    const menuButton = getByRole('button');
+
+    fireEvent.click(menuButton);
+
+    getByRole('button', { name: 'Sign in' });
+  });
+});


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR adds tests to the `UserOptions` component.

---

#### :pushpin: Notes:

* Let me know if there are other uses cases to test.

---

#### :heavy_check_mark: Tasks:

* Created tests.

---

#### :play_or_pause_button: Demo:
 Test coverage improvement:
   Before: 
   ![Screen Shot 2021-01-20 at 17 51 01](https://user-images.githubusercontent.com/67390791/105233052-126f7780-5b48-11eb-8ada-4ef3cc879ca9.png)

   After: 
![Screen Shot 2021-01-21 at 11 39 18](https://user-images.githubusercontent.com/67390791/105365748-5cef0380-5bdd-11eb-8d4c-cb8f25418835.png)


@loopstudio/react-devs
