### PR TITLE
Add Navbar Menu test

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "pre-push": "eslint ."
   },
   "jest": {
-    "coverageReporters": ["text-summary"],
     "coverageThreshold": {
       "global": {
         "branches": 85,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pre-push": "eslint ."
   },
   "jest": {
+    "coverageReporters": ["json", "lcov", "text", "clover", "text-summary"],
     "coverageThreshold": {
       "global": {
         "branches": 85,

--- a/src/features/app/components/Navbar/Menu.test.js
+++ b/src/features/app/components/Navbar/Menu.test.js
@@ -56,14 +56,14 @@ describe('Menu', () => {
   });
 
   it('navigates to sign in', async () => {
-    const { history, getAllByText, getByRole } = renderWithRouter(<Navbar />, {
+    const { history, getByRole } = renderWithRouter(<Navbar />, {
       history: ['/forgot-password'],
     });
 
     const menuButton = getByRole('button');
     fireEvent.click(menuButton);
 
-    const signInButton = getAllByText('Sign in')[1];
+    const signInButton = getByRole('button', { name: 'Sign in' });
     fireEvent.click(signInButton);
 
     await waitFor(() => {
@@ -73,14 +73,14 @@ describe('Menu', () => {
   });
 
   it('navigates to sign up', async () => {
-    const { history, getAllByText, getByRole } = renderWithRouter(<Navbar />, {
+    const { history, getByRole } = renderWithRouter(<Navbar />, {
       history: ['/forgot-password'],
     });
 
     const menuButton = getByRole('button');
     fireEvent.click(menuButton);
 
-    const signUpButton = getAllByText('Sign up')[1];
+    const signUpButton = getByRole('button', { name: 'Sign up' });
     fireEvent.click(signUpButton);
 
     await waitFor(() => {

--- a/src/features/app/components/Navbar/Menu.test.js
+++ b/src/features/app/components/Navbar/Menu.test.js
@@ -1,13 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import {
-  fireEvent,
-  render,
-  renderWithProviders,
-  renderWithRouter,
-  waitFor,
-} from 'testUtils';
-import Button from 'features/app/components/Navbar/Button';
+import { fireEvent, renderWithRouter, waitFor } from 'testUtils';
+import { mockSignOutSuccess } from 'testUtils/mocks/auth';
 import Navbar from './Navbar';
 
 describe('Menu', () => {
@@ -50,6 +44,8 @@ describe('Menu', () => {
   });
 
   it('logs out', async () => {
+    const mockedRequest = mockSignOutSuccess();
+
     const { history, getByText, getByRole } = renderWithRouter(<Navbar />, {
       history: ['/'],
       state: fakeState,
@@ -62,6 +58,7 @@ describe('Menu', () => {
     fireEvent.click(signOutButton);
 
     await waitFor(() => {
+      expect(mockedRequest.isDone()).toBeTruthy();
       expect(signOutButton).toBeInTheDocument();
       expect(history.location.pathname).toEqual('/sign-in');
     });

--- a/src/features/app/components/Navbar/Menu.test.js
+++ b/src/features/app/components/Navbar/Menu.test.js
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+  fireEvent,
+  render,
+  renderWithProviders,
+  renderWithRouter,
+  waitFor,
+} from 'testUtils';
+import Button from 'features/app/components/Navbar/Button';
+import Navbar from './Navbar';
+
+describe('Menu', () => {
+  const fakeState = {
+    auth: {
+      user: {
+        id: 1,
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane.doe@example.com',
+        locale: 'en',
+        createdAt: '2020-04-21T21:20:35.663-04:00',
+        updatedAt: '2020-04-21T22:22:56.291-04:00',
+      },
+      session: {
+        uid: 'jane.doe@example.com',
+        client: 'client',
+        accessToken: 'token',
+      },
+      guestLocale: 'en',
+    },
+  };
+
+  it('navigates to settings', async () => {
+    const { history, getByText, getByRole } = renderWithRouter(<Navbar />, {
+      history: ['/'],
+      state: fakeState,
+    });
+
+    const menuButton = getByRole('button');
+    fireEvent.click(menuButton);
+
+    const settingsButton = getByText('Account settings');
+    fireEvent.click(settingsButton);
+
+    await waitFor(() => {
+      expect(settingsButton).toBeInTheDocument();
+      expect(history.location.pathname).toEqual('/settings');
+    });
+  });
+
+  it('logs out', async () => {
+    const { history, getByText, getByRole } = renderWithRouter(<Navbar />, {
+      history: ['/'],
+      state: fakeState,
+    });
+
+    const menuButton = getByRole('button');
+    fireEvent.click(menuButton);
+
+    const signOutButton = getByText('Sign out');
+    fireEvent.click(signOutButton);
+
+    await waitFor(() => {
+      expect(signOutButton).toBeInTheDocument();
+      expect(history.location.pathname).toEqual('/sign-in');
+    });
+  });
+});

--- a/src/features/app/components/Navbar/Menu.test.js
+++ b/src/features/app/components/Navbar/Menu.test.js
@@ -1,27 +1,18 @@
 import '@testing-library/jest-dom/extend-expect';
 
 import { fireEvent, renderWithRouter, waitFor } from 'testUtils';
-import { mockSignOutSuccess } from 'testUtils/mocks/auth';
+import {
+  userData,
+  authenticationHeaders,
+  mockSignOutSuccess,
+} from 'testUtils/mocks/auth';
 import Navbar from './Navbar';
 
 describe('Menu', () => {
   const fakeState = {
     auth: {
-      user: {
-        id: 1,
-        firstName: 'Jane',
-        lastName: 'Doe',
-        email: 'jane.doe@example.com',
-        locale: 'en',
-        createdAt: '2020-04-21T21:20:35.663-04:00',
-        updatedAt: '2020-04-21T22:22:56.291-04:00',
-      },
-      session: {
-        uid: 'jane.doe@example.com',
-        client: 'client',
-        accessToken: 'token',
-      },
-      guestLocale: 'en',
+      user: userData,
+      session: authenticationHeaders,
     },
   };
 
@@ -61,6 +52,40 @@ describe('Menu', () => {
       expect(mockedRequest.isDone()).toBeTruthy();
       expect(signOutButton).toBeInTheDocument();
       expect(history.location.pathname).toEqual('/sign-in');
+    });
+  });
+
+  it('navigates to sign in', async () => {
+    const { history, getAllByText, getByRole } = renderWithRouter(<Navbar />, {
+      history: ['/forgot-password'],
+    });
+
+    const menuButton = getByRole('button');
+    fireEvent.click(menuButton);
+
+    const signInButton = getAllByText('Sign in')[1];
+    fireEvent.click(signInButton);
+
+    await waitFor(() => {
+      expect(signInButton).toBeInTheDocument();
+      expect(history.location.pathname).toEqual('/sign-in');
+    });
+  });
+
+  it('navigates to sign up', async () => {
+    const { history, getAllByText, getByRole } = renderWithRouter(<Navbar />, {
+      history: ['/forgot-password'],
+    });
+
+    const menuButton = getByRole('button');
+    fireEvent.click(menuButton);
+
+    const signUpButton = getAllByText('Sign up')[1];
+    fireEvent.click(signUpButton);
+
+    await waitFor(() => {
+      expect(signUpButton).toBeInTheDocument();
+      expect(history.location.pathname).toEqual('/sign-up');
     });
   });
 });

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -114,3 +114,6 @@ export const mockResetPasswordFailure = (password, resetPasswordToken) =>
     .reply(500, {
       errors: ['Connection error'],
     });
+
+export const mockSignOutSuccess = () =>
+  baseMock.delete('/users/sign_out').reply(200);


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR adds tests for the Navbar Menu component.

---

#### :pushpin: Notes:

* Added the previously removed coverage report table that shows data from all the files. To do it, it's necessary to add `["json", "lcov", "text", "clover"]` to the `coverageReporters` option in the package.json.

---

#### :heavy_check_mark: Tasks:

* Created tests.
* Added mockSignOutSuccess.

---

#### :play_or_pause_button: Demo:

Before:
![image](https://user-images.githubusercontent.com/60147387/110376915-869ba700-8032-11eb-8a8e-c7b96a1507a3.png)
![image](https://user-images.githubusercontent.com/60147387/110377180-d9755e80-8032-11eb-97f4-b7cdd7f5d6b1.png)


After:
![image](https://user-images.githubusercontent.com/60147387/110376593-273d9700-8032-11eb-9c64-674c1a8e94b5.png)
![image](https://user-images.githubusercontent.com/60147387/110376336-d3cb4900-8031-11eb-849d-f9507d1b5c1f.png)


@loopstudio/react-devs
