### PR TITLE
Fix tests that depend on redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
+    "test:debug-nock": "DEBUG=nock.* react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:coverage": "react-scripts test --ci --env=jest-environment-jsdom-sixteen --coverage --watchAll=false",
     "lint": "eslint .",
     "eject": "react-scripts eject",

--- a/src/features/app/components/App/App.test.js
+++ b/src/features/app/components/App/App.test.js
@@ -4,7 +4,7 @@ import { render } from 'testUtils';
 import App from 'features/app/components/App';
 
 describe('App', () => {
-  it('should render without crashing', () => {
+  it('renders without crashing', () => {
     render(<App />);
   });
 });

--- a/src/features/app/components/Navbar/NavBar.test.js
+++ b/src/features/app/components/Navbar/NavBar.test.js
@@ -23,29 +23,33 @@ describe('Menu', () => {
     });
   });
 
-  it('renders the settings and sign out buttons when authenticated', () => {
-    const { queryByText } = render(<Menu isAuthenticated />);
-    const settingButton = queryByText('Account settings');
-    const signOutButton = queryByText('Sign out');
-    const signUpButton = queryByText('Sign up');
-    const signInButton = queryByText('Sign in');
+  describe('when user is authenticated', () => {
+    it('renders the settings and sign out buttons', () => {
+      const { queryByText } = render(<Menu isAuthenticated />);
+      const settingButton = queryByText('Account settings');
+      const signOutButton = queryByText('Sign out');
+      const signUpButton = queryByText('Sign up');
+      const signInButton = queryByText('Sign in');
 
-    expect(settingButton).toBeInTheDocument();
-    expect(signOutButton).toBeInTheDocument();
-    expect(signUpButton).toBeNull();
-    expect(signInButton).toBeNull();
+      expect(settingButton).toBeInTheDocument();
+      expect(signOutButton).toBeInTheDocument();
+      expect(signUpButton).toBeNull();
+      expect(signInButton).toBeNull();
+    });
   });
 
-  it('renders the sign in and sign up buttons when it is not authenticated', () => {
-    const { queryByText } = render(<Menu />);
-    const signUpButton = queryByText('Sign up');
-    const signInButton = queryByText('Sign in');
-    const settingButton = queryByText('Account settings');
-    const signOutButton = queryByText('Sign out');
+  describe('when user is not authenticated', () => {
+    it('renders the sign in and sign up buttons', () => {
+      const { queryByText } = render(<Menu />);
+      const signUpButton = queryByText('Sign up');
+      const signInButton = queryByText('Sign in');
+      const settingButton = queryByText('Account settings');
+      const signOutButton = queryByText('Sign out');
 
-    expect(signUpButton).toBeInTheDocument();
-    expect(signInButton).toBeInTheDocument();
-    expect(settingButton).toBeNull();
-    expect(signOutButton).toBeNull();
+      expect(signUpButton).toBeInTheDocument();
+      expect(signInButton).toBeInTheDocument();
+      expect(settingButton).toBeNull();
+      expect(signOutButton).toBeNull();
+    });
   });
 });

--- a/src/features/app/components/Settings/Form.js
+++ b/src/features/app/components/Settings/Form.js
@@ -40,7 +40,7 @@ const SettingsForm = () => {
   const onSubmit = async (attributes) => {
     setIsLoading(true);
     try {
-      updateUser(attributes);
+      await updateUser(attributes);
       setIsResponseSuccess(true);
     } catch (error) {
       handleErrors(error, formMethods.setError);

--- a/src/features/app/components/Settings/Settings.test.js
+++ b/src/features/app/components/Settings/Settings.test.js
@@ -42,179 +42,183 @@ const fakeState = {
 };
 
 describe('Settings', () => {
-  it('confirms when account settings were changed successfully', async () => {
-    const mockedRequest = mockUpdateUserSuccess(fakeSettingsData);
+  describe('account settings', () => {
+    it('confirms when account settings were changed successfully', async () => {
+      const mockedRequest = mockUpdateUserSuccess(fakeSettingsData);
 
-    const { getByLabelText, getByRole, getByText } = render(<Settings />, {
-      state: fakeState,
+      const { getByLabelText, getByRole, getByText } = render(<Settings />, {
+        state: fakeState,
+      });
+
+      const firstName = getByLabelText('First Name');
+      const lastName = getByLabelText('Last Name');
+      const locale = getByLabelText('Language');
+      const submitButton = getByRole('button', { name: 'Update Settings' });
+
+      fillInput(firstName, fakeSettingsData.firstName);
+      fillInput(lastName, fakeSettingsData.lastName);
+      fillInput(locale, fakeSettingsData.locale);
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockedRequest.isDone()).toBeTruthy();
+        expect(
+          getByText('Your settings have been updated successfully')
+        ).toBeInTheDocument();
+      });
     });
 
-    const firstName = getByLabelText('First Name');
-    const lastName = getByLabelText('Last Name');
-    const locale = getByLabelText('Language');
-    const submitButton = getByRole('button', { name: 'Update Settings' });
+    it('renders API errors when changing account settings', async () => {
+      const mockedRequest = mockUpdateUserFailure(fakeSettingsData);
 
-    fillInput(firstName, fakeSettingsData.firstName);
-    fillInput(lastName, fakeSettingsData.lastName);
-    fillInput(locale, fakeSettingsData.locale);
+      const { getByLabelText, getByRole, getByText } = render(<Settings />, {
+        state: fakeState,
+      });
+      const firstName = getByLabelText('First Name');
+      const lastName = getByLabelText('Last Name');
+      const locale = getByLabelText('Language');
+      const submitButton = getByRole('button', { name: 'Update Settings' });
 
-    fireEvent.click(submitButton);
+      fillInput(firstName, fakeSettingsData.firstName);
+      fillInput(lastName, fakeSettingsData.lastName);
+      fillInput(locale, fakeSettingsData.locale);
 
-    await waitFor(() => {
-      expect(mockedRequest.isDone()).toBeTruthy();
-      expect(
-        getByText('Your settings have been updated successfully')
-      ).toBeInTheDocument();
-    });
-  });
+      fireEvent.click(submitButton);
 
-  it('renders API errors when changing account settings', async () => {
-    const mockedRequest = mockUpdateUserFailure(fakeSettingsData);
-
-    const { getByLabelText, getByRole, getByText } = render(<Settings />, {
-      state: fakeState,
-    });
-    const firstName = getByLabelText('First Name');
-    const lastName = getByLabelText('Last Name');
-    const locale = getByLabelText('Language');
-    const submitButton = getByRole('button', { name: 'Update Settings' });
-
-    fillInput(firstName, fakeSettingsData.firstName);
-    fillInput(lastName, fakeSettingsData.lastName);
-    fillInput(locale, fakeSettingsData.locale);
-
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockedRequest.isDone()).toBeTruthy();
-      expect(getByText('Some scary error')).toBeInTheDocument();
-    });
-  });
-
-  it('requires the first name when changing account settings', async () => {
-    const { getByLabelText, getByRole, findByText } = render(<Settings />, {
-      state: fakeState,
-    });
-    const firstName = getByLabelText('First Name');
-    const submitButton = getByRole('button', { name: 'Update Settings' });
-
-    fillInput(firstName, '');
-
-    fireEvent.click(submitButton);
-
-    const firstNameError = await findByText('Required');
-
-    expect(firstNameError).toBeInTheDocument();
-  });
-
-  it('confirms when the password was changed successfully', async () => {
-    const mockedRequest = mockUpdateUserSuccess(
-      fakePasswordData.user,
-      fakePasswordData.passwordCheck
-    );
-
-    const { getByLabelText, getByRole, getByText } = render(<Settings />, {
-      state: fakeState,
+      await waitFor(() => {
+        expect(mockedRequest.isDone()).toBeTruthy();
+        expect(getByText('Some scary error')).toBeInTheDocument();
+      });
     });
 
-    const currentPasswordInput = getByLabelText('Current Password');
-    const newPasswordInput = getByLabelText('New Password');
-    const submitButton = getByRole('button', { name: 'Update Password' });
+    it('requires the first name when changing account settings', async () => {
+      const { getByLabelText, getByRole, findByText } = render(<Settings />, {
+        state: fakeState,
+      });
+      const firstName = getByLabelText('First Name');
+      const submitButton = getByRole('button', { name: 'Update Settings' });
 
-    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
-    fillInput(newPasswordInput, fakePasswordData.user.password);
+      fillInput(firstName, '');
 
-    fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
 
-    await waitFor(() => {
-      expect(mockedRequest.isDone()).toBeTruthy();
-      expect(
-        getByText('Your password has been changed successfully')
-      ).toBeInTheDocument();
+      const firstNameError = await findByText('Required');
+
+      expect(firstNameError).toBeInTheDocument();
     });
   });
 
-  it('renders API errors when changing the password', async () => {
-    const mockedRequest = mockUpdateUserFailure(
-      fakePasswordData.user,
-      fakePasswordData.passwordCheck
-    );
+  describe('change password', () => {
+    it('confirms when the password was changed successfully', async () => {
+      const mockedRequest = mockUpdateUserSuccess(
+        fakePasswordData.user,
+        fakePasswordData.passwordCheck
+      );
 
-    const { getByLabelText, getByRole, getByText } = render(<Settings />, {
-      state: fakeState,
+      const { getByLabelText, getByRole, getByText } = render(<Settings />, {
+        state: fakeState,
+      });
+
+      const currentPasswordInput = getByLabelText('Current Password');
+      const newPasswordInput = getByLabelText('New Password');
+      const submitButton = getByRole('button', { name: 'Update Password' });
+
+      fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+      fillInput(newPasswordInput, fakePasswordData.user.password);
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockedRequest.isDone()).toBeTruthy();
+        expect(
+          getByText('Your password has been changed successfully')
+        ).toBeInTheDocument();
+      });
     });
 
-    const currentPasswordInput = getByLabelText('Current Password');
-    const newPasswordInput = getByLabelText('New Password');
-    const submitButton = getByRole('button', { name: 'Update Password' });
+    it('renders API errors when changing the password', async () => {
+      const mockedRequest = mockUpdateUserFailure(
+        fakePasswordData.user,
+        fakePasswordData.passwordCheck
+      );
 
-    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
-    fillInput(newPasswordInput, fakePasswordData.user.password);
+      const { getByLabelText, getByRole, getByText } = render(<Settings />, {
+        state: fakeState,
+      });
 
-    fireEvent.click(submitButton);
+      const currentPasswordInput = getByLabelText('Current Password');
+      const newPasswordInput = getByLabelText('New Password');
+      const submitButton = getByRole('button', { name: 'Update Password' });
 
-    await waitFor(() => {
-      expect(mockedRequest.isDone()).toBeTruthy();
-      expect(getByText('Some scary error')).toBeInTheDocument();
-    });
-  });
+      fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+      fillInput(newPasswordInput, fakePasswordData.user.password);
 
-  it('requires a new password when changing the password', async () => {
-    const { getByLabelText, getByRole, findByText } = render(<Settings />, {
-      state: fakeState,
-    });
+      fireEvent.click(submitButton);
 
-    const currentPasswordInput = getByLabelText('Current Password');
-    const newPasswordInput = getByLabelText('New Password');
-    const submitButton = getByRole('button', { name: 'Update Password' });
-
-    fillInput(currentPasswordInput, '');
-    fillInput(newPasswordInput, fakePasswordData.user.password);
-
-    fireEvent.click(submitButton);
-
-    const currentPasswordError = await findByText('Required');
-
-    expect(currentPasswordError).toBeInTheDocument();
-  });
-
-  it('requires the new password when changing the password', async () => {
-    const { getByLabelText, getByRole, findByText } = render(<Settings />, {
-      state: fakeState,
+      await waitFor(() => {
+        expect(mockedRequest.isDone()).toBeTruthy();
+        expect(getByText('Some scary error')).toBeInTheDocument();
+      });
     });
 
-    const currentPasswordInput = getByLabelText('Current Password');
-    const newPasswordInput = getByLabelText('New Password');
-    const submitButton = getByRole('button', { name: 'Update Password' });
+    it('requires the current password when changing the password', async () => {
+      const { getByLabelText, getByRole, findByText } = render(<Settings />, {
+        state: fakeState,
+      });
 
-    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
-    fillInput(newPasswordInput, '');
+      const currentPasswordInput = getByLabelText('Current Password');
+      const newPasswordInput = getByLabelText('New Password');
+      const submitButton = getByRole('button', { name: 'Update Password' });
 
-    fireEvent.click(submitButton);
+      fillInput(currentPasswordInput, '');
+      fillInput(newPasswordInput, fakePasswordData.user.password);
 
-    const newPasswordError = await findByText('Required');
+      fireEvent.click(submitButton);
 
-    expect(newPasswordError).toBeInTheDocument();
-  });
+      const currentPasswordError = await findByText('Required');
 
-  it('requires the current password to be at least 8 chars', async () => {
-    const { getByLabelText, getByRole, findByText } = render(<Settings />, {
-      state: fakeState,
+      expect(currentPasswordError).toBeInTheDocument();
     });
 
-    const currentPasswordInput = getByLabelText('Current Password');
-    const newPasswordInput = getByLabelText('New Password');
-    const submitButton = getByRole('button', { name: 'Update Password' });
+    it('requires the new password when changing the password', async () => {
+      const { getByLabelText, getByRole, findByText } = render(<Settings />, {
+        state: fakeState,
+      });
 
-    fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
-    fillInput(newPasswordInput, 'pass');
+      const currentPasswordInput = getByLabelText('Current Password');
+      const newPasswordInput = getByLabelText('New Password');
+      const submitButton = getByRole('button', { name: 'Update Password' });
 
-    fireEvent.click(submitButton);
+      fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+      fillInput(newPasswordInput, '');
 
-    const newPasswordError = await findByText(
-      'Password too short, minimum length is 8 characters'
-    );
+      fireEvent.click(submitButton);
 
-    expect(newPasswordError).toBeInTheDocument();
+      const newPasswordError = await findByText('Required');
+
+      expect(newPasswordError).toBeInTheDocument();
+    });
+
+    it('requires the current password to be at least 8 chars', async () => {
+      const { getByLabelText, getByRole, findByText } = render(<Settings />, {
+        state: fakeState,
+      });
+
+      const currentPasswordInput = getByLabelText('Current Password');
+      const newPasswordInput = getByLabelText('New Password');
+      const submitButton = getByRole('button', { name: 'Update Password' });
+
+      fillInput(currentPasswordInput, fakePasswordData.passwordCheck);
+      fillInput(newPasswordInput, 'pass');
+
+      fireEvent.click(submitButton);
+
+      const newPasswordError = await findByText(
+        'Password too short, minimum length is 8 characters'
+      );
+
+      expect(newPasswordError).toBeInTheDocument();
+    });
   });
 });

--- a/src/features/app/services/httpClient.js
+++ b/src/features/app/services/httpClient.js
@@ -1,23 +1,10 @@
 import axios from 'axios';
 import applyCaseMiddleware from 'axios-case-converter';
 
-// import authMiddleware from 'features/auth/services/middlewares/auth';
-
 const httpClient = axios.create({
   baseURL: process.env.REACT_APP_API_URL,
   headers: { accept: 'application/json' },
   params: {},
 });
-
-// const applyMiddlewares = (client) =>
-//   authMiddleware(applyCaseMiddleware(client));
-
-// class HTTPCLient {
-//   session = null;
-
-//   constructor() {
-//     this.subscriptionClient = subscriptionClient;
-//   }
-// }
 
 export default applyCaseMiddleware(httpClient);

--- a/src/features/auth/components/ForgotPassword/ForgotPassword.test.js
+++ b/src/features/auth/components/ForgotPassword/ForgotPassword.test.js
@@ -23,190 +23,208 @@ const fakeVerificationCode = '123456';
 const password = 'password';
 
 describe('ForgotPassword', () => {
-  it('submits correctly', async () => {
-    const {
-      getByLabelText,
-      getByRole,
-      getByText,
-      history,
-    } = renderWithRouter(<ForgotPassword />, { history: ['/forgot-password'] });
+  describe('on success', () => {
+    it('submits correctly', async () => {
+      const {
+        getByLabelText,
+        getByRole,
+        getByText,
+        history,
+      } = renderWithRouter(<ForgotPassword />, {
+        history: ['/forgot-password'],
+      });
 
-    const mockGetVerificationCode = mockGetVerificationCodeSuccess(fakeEmail);
+      const mockGetVerificationCode = mockGetVerificationCodeSuccess(fakeEmail);
 
-    const emailInput = getByLabelText('Email');
-    const resetButton = getByRole('button', { name: 'Reset Password' });
+      const emailInput = getByLabelText('Email');
+      const resetButton = getByRole('button', { name: 'Reset Password' });
 
-    fillInput(emailInput, fakeEmail);
+      fillInput(emailInput, fakeEmail);
 
-    fireEvent.click(resetButton);
+      fireEvent.click(resetButton);
 
-    await waitFor(() => {
-      expect(mockGetVerificationCode.isDone()).toBeTruthy();
-      expect(
-        getByText(
-          'Step 2: Enter the verification code we just sent to your email address'
-        )
-      ).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(mockGetVerificationCode.isDone()).toBeTruthy();
+        expect(
+          getByText(
+            'Step 2: Enter the verification code we just sent to your email address'
+          )
+        ).toBeInTheDocument();
+      });
 
-    const mockVerifyToken = mockVerifyTokenSuccess(fakeVerificationCode);
-    const code = getByLabelText('Code');
-    const nextButton = getByRole('button', { name: 'Next' });
+      const mockVerifyToken = mockVerifyTokenSuccess(fakeVerificationCode);
+      const code = getByLabelText('Code');
+      const nextButton = getByRole('button', { name: 'Next' });
 
-    fillInput(code, fakeVerificationCode);
+      fillInput(code, fakeVerificationCode);
 
-    fireEvent.click(nextButton);
+      fireEvent.click(nextButton);
 
-    await waitFor(() => {
-      expect(mockVerifyToken.isDone()).toBeTruthy();
-      expect(getByText('Step 3: Enter your new password')).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(mockVerifyToken.isDone()).toBeTruthy();
+        expect(
+          getByText('Step 3: Enter your new password')
+        ).toBeInTheDocument();
+      });
 
-    const mockResetPassword = mockResetPasswordSuccess(
-      password,
-      fakeVerificationCode
-    );
+      const mockResetPassword = mockResetPasswordSuccess(
+        password,
+        fakeVerificationCode
+      );
 
-    const passwordInput = getByLabelText('Password');
-    const confirmPasswordInput = getByLabelText('Confirm password');
+      const passwordInput = getByLabelText('Password');
+      const confirmPasswordInput = getByLabelText('Confirm password');
 
-    const submitButton = getByRole('button', { name: 'Next' });
+      const submitButton = getByRole('button', { name: 'Next' });
 
-    fillInput(passwordInput, password);
-    fillInput(confirmPasswordInput, password);
+      fillInput(passwordInput, password);
+      fillInput(confirmPasswordInput, password);
 
-    fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
 
-    await waitFor(() => {
-      expect(mockResetPassword.isDone()).toBeTruthy();
-      expect(history.location.pathname).toEqual('/');
-    });
-  });
-
-  it('shows errors for invalid values', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<ForgotPassword />);
-
-    const email = getByLabelText('Email');
-    const submitButton = getByRole('button', { name: 'Reset Password' });
-
-    fillInput(email, 'invalid');
-
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(getByText('Invalid email')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockResetPassword.isDone()).toBeTruthy();
+        expect(history.location.pathname).toEqual('/');
+      });
     });
   });
 
-  it('shows error on email form response failure', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<ForgotPassword />);
+  describe('on failure', () => {
+    it('shows errors for invalid values', async () => {
+      const { getByLabelText, getByRole, getByText } = render(
+        <ForgotPassword />
+      );
 
-    const mockedRequest = mockGetVerificationCodeFailure(fakeEmail);
+      const email = getByLabelText('Email');
+      const submitButton = getByRole('button', { name: 'Reset Password' });
 
-    const email = getByLabelText('Email');
-    const submitButton = getByRole('button', { name: 'Reset Password' });
+      fillInput(email, 'invalid');
 
-    fillInput(email, fakeEmail);
+      fireEvent.click(submitButton);
 
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockedRequest.isDone()).toBeTruthy();
-      expect(
-        getByText(`Unable to find user with email ${fakeEmail}`)
-      ).toBeInTheDocument();
-    });
-  });
-
-  it('shows error on token form response failure', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<ForgotPassword />);
-    const mockGetVerificationCode = mockGetVerificationCodeSuccess(fakeEmail);
-
-    const emailInput = getByLabelText('Email');
-    const resetButton = getByRole('button', { name: 'Reset Password' });
-
-    fillInput(emailInput, fakeEmail);
-
-    fireEvent.click(resetButton);
-
-    await waitFor(() => {
-      expect(mockGetVerificationCode.isDone()).toBeTruthy();
-      expect(
-        getByText(
-          'Step 2: Enter the verification code we just sent to your email address'
-        )
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(getByText('Invalid email')).toBeInTheDocument();
+      });
     });
 
-    const mockVerifyToken = mockVerifyTokenFailure(fakeVerificationCode);
-    const code = getByLabelText('Code');
-    const nextButton = getByRole('button', { name: 'Next' });
+    it('shows error on email form response failure', async () => {
+      const { getByLabelText, getByRole, getByText } = render(
+        <ForgotPassword />
+      );
 
-    fillInput(code, fakeVerificationCode);
+      const mockedRequest = mockGetVerificationCodeFailure(fakeEmail);
 
-    fireEvent.click(nextButton);
+      const email = getByLabelText('Email');
+      const submitButton = getByRole('button', { name: 'Reset Password' });
 
-    await waitFor(() => {
-      expect(mockVerifyToken.isDone()).toBeTruthy();
-      expect(
-        getByText('The reset password token is invalid')
-      ).toBeInTheDocument();
-    });
-  });
+      fillInput(email, fakeEmail);
 
-  it('shows error on password form response failure', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<ForgotPassword />);
+      fireEvent.click(submitButton);
 
-    const mockGetVerificationCode = mockGetVerificationCodeSuccess(fakeEmail);
-
-    const emailInput = getByLabelText('Email');
-    const resetButton = getByRole('button', { name: 'Reset Password' });
-
-    fillInput(emailInput, fakeEmail);
-
-    fireEvent.click(resetButton);
-
-    await waitFor(() => {
-      expect(mockGetVerificationCode.isDone()).toBeTruthy();
-      expect(
-        getByText(
-          'Step 2: Enter the verification code we just sent to your email address'
-        )
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockedRequest.isDone()).toBeTruthy();
+        expect(
+          getByText(`Unable to find user with email ${fakeEmail}`)
+        ).toBeInTheDocument();
+      });
     });
 
-    const mockVerifyToken = mockVerifyTokenSuccess(fakeVerificationCode);
+    it('shows error on token form response failure', async () => {
+      const { getByLabelText, getByRole, getByText } = render(
+        <ForgotPassword />
+      );
+      const mockGetVerificationCode = mockGetVerificationCodeSuccess(fakeEmail);
 
-    const code = getByLabelText('Code');
-    const nextButton = getByRole('button', { name: 'Next' });
+      const emailInput = getByLabelText('Email');
+      const resetButton = getByRole('button', { name: 'Reset Password' });
 
-    fillInput(code, fakeVerificationCode);
+      fillInput(emailInput, fakeEmail);
 
-    fireEvent.click(nextButton);
+      fireEvent.click(resetButton);
 
-    await waitFor(() => {
-      expect(mockVerifyToken.isDone()).toBeTruthy();
-      expect(getByText('Step 3: Enter your new password')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockGetVerificationCode.isDone()).toBeTruthy();
+        expect(
+          getByText(
+            'Step 2: Enter the verification code we just sent to your email address'
+          )
+        ).toBeInTheDocument();
+      });
+
+      const mockVerifyToken = mockVerifyTokenFailure(fakeVerificationCode);
+      const code = getByLabelText('Code');
+      const nextButton = getByRole('button', { name: 'Next' });
+
+      fillInput(code, fakeVerificationCode);
+
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockVerifyToken.isDone()).toBeTruthy();
+        expect(
+          getByText('The reset password token is invalid')
+        ).toBeInTheDocument();
+      });
     });
 
-    const mockResetPassword = mockResetPasswordFailure(
-      password,
-      fakeVerificationCode
-    );
+    it('shows error on password form response failure', async () => {
+      const { getByLabelText, getByRole, getByText } = render(
+        <ForgotPassword />
+      );
 
-    const passwordInput = getByLabelText('Password');
-    const confirmPasswordInput = getByLabelText('Confirm password');
+      const mockGetVerificationCode = mockGetVerificationCodeSuccess(fakeEmail);
 
-    const submitButton = getByRole('button', { name: 'Next' });
+      const emailInput = getByLabelText('Email');
+      const resetButton = getByRole('button', { name: 'Reset Password' });
 
-    fillInput(passwordInput, password);
-    fillInput(confirmPasswordInput, password);
+      fillInput(emailInput, fakeEmail);
 
-    fireEvent.click(submitButton);
+      fireEvent.click(resetButton);
 
-    await waitFor(() => {
-      expect(mockResetPassword.isDone()).toBeTruthy();
-      expect(getByText('Connection error')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(mockGetVerificationCode.isDone()).toBeTruthy();
+        expect(
+          getByText(
+            'Step 2: Enter the verification code we just sent to your email address'
+          )
+        ).toBeInTheDocument();
+      });
+
+      const mockVerifyToken = mockVerifyTokenSuccess(fakeVerificationCode);
+
+      const code = getByLabelText('Code');
+      const nextButton = getByRole('button', { name: 'Next' });
+
+      fillInput(code, fakeVerificationCode);
+
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockVerifyToken.isDone()).toBeTruthy();
+        expect(
+          getByText('Step 3: Enter your new password')
+        ).toBeInTheDocument();
+      });
+
+      const mockResetPassword = mockResetPasswordFailure(
+        password,
+        fakeVerificationCode
+      );
+
+      const passwordInput = getByLabelText('Password');
+      const confirmPasswordInput = getByLabelText('Confirm password');
+
+      const submitButton = getByRole('button', { name: 'Next' });
+
+      fillInput(passwordInput, password);
+      fillInput(confirmPasswordInput, password);
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockResetPassword.isDone()).toBeTruthy();
+        expect(getByText('Connection error')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/features/auth/components/ForgotPassword/PasswordForm.js
+++ b/src/features/auth/components/ForgotPassword/PasswordForm.js
@@ -3,7 +3,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
-// import { useDispatch } from 'react-redux';
 import { object, ref, string } from 'yup';
 import PropTypes from 'prop-types';
 

--- a/src/features/auth/components/SignIn/Form.js
+++ b/src/features/auth/components/SignIn/Form.js
@@ -34,7 +34,6 @@ const SignInForm = () => {
       history.replace('/');
     } catch (error) {
       setIsLoading(false);
-      console.log(error);
       handleErrors(error, formMethods.setError);
     }
   };

--- a/src/features/auth/components/SignIn/Form.js
+++ b/src/features/auth/components/SignIn/Form.js
@@ -3,11 +3,9 @@ import React, { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { useIntl } from 'react-intl';
-// import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { object, string } from 'yup';
 
-// import { signIn } from 'features/auth';
 import { useAuth } from 'features/auth';
 import Form from 'features/app/components/Form';
 import { handleErrors } from 'helpers/errors';

--- a/src/features/auth/components/SignIn/SignIn.test.js
+++ b/src/features/auth/components/SignIn/SignIn.test.js
@@ -17,7 +17,7 @@ const fakeCredentials = {
 };
 
 describe('SignIn', () => {
-  it('should submit correctly', async () => {
+  it('submits correctly', async () => {
     const mockedRequest = mockSignInSuccess(fakeCredentials);
 
     const { getByLabelText, getByRole, history } = renderWithRouter(
@@ -39,7 +39,7 @@ describe('SignIn', () => {
     });
   });
 
-  it('should show error on response failure', async () => {
+  it('shows error on response failure', async () => {
     const mockedRequest = mockSignInFailure(fakeCredentials);
 
     const { getByLabelText, getByRole, getByText } = render(<SignIn />);
@@ -58,7 +58,7 @@ describe('SignIn', () => {
     });
   });
 
-  it('should show errors for invalid values', async () => {
+  it('shows errors for invalid values', async () => {
     const { getByLabelText, getByRole, findByText } = render(<SignIn />);
     const submitButton = getByRole('button');
     const email = getByLabelText('Email');

--- a/src/features/auth/components/SignUp/SignUp.test.js
+++ b/src/features/auth/components/SignUp/SignUp.test.js
@@ -20,7 +20,7 @@ const fakeUser = {
 };
 
 describe('SignUp', () => {
-  it('should submit correctly', async () => {
+  it('submits correctly', async () => {
     const mockedRequest = mockSignUpSuccess(fakeUser);
 
     const { getByLabelText, getByRole, history } = renderWithRouter(
@@ -47,7 +47,7 @@ describe('SignUp', () => {
     });
   });
 
-  it('should show error on response failure', async () => {
+  it('shows error on response failure', async () => {
     const mockedRequest = mockSignUpFailure(fakeUser);
 
     const { getByLabelText, getByRole, getByText } = render(<SignUp />);
@@ -70,7 +70,7 @@ describe('SignUp', () => {
     });
   });
 
-  it('should show errors for invalid values', async () => {
+  it('shows errors for invalid values', async () => {
     const { getByLabelText, getByRole, findByText } = render(<SignUp />);
     const email = getByLabelText('Email');
     const password = getByLabelText('Password');

--- a/src/features/auth/context.js
+++ b/src/features/auth/context.js
@@ -19,8 +19,8 @@ const initialState = () => {
 };
 
 // eslint-disable-next-line react/prop-types
-export const AuthProvider = ({ httpClient, children }) => {
-  const [state, setState] = useState(initialState);
+export const AuthProvider = ({ children, defaultValue, httpClient }) => {
+  const [state, setState] = useState(defaultValue || initialState);
   const { user, session, isLoading } = state;
 
   const validateSession = useCallback(async () => {

--- a/src/features/auth/context.js
+++ b/src/features/auth/context.js
@@ -21,8 +21,8 @@ const initialState = () => {
 };
 
 // eslint-disable-next-line react/prop-types
-export const AuthProvider = ({ children, defaultValue, httpClient }) => {
-  const [state, setState] = useState(defaultValue || initialState);
+export const AuthProvider = ({ children, prepopulatedState, httpClient }) => {
+  const [state, setState] = useState(prepopulatedState || initialState);
   const { user, session, isLoading } = state;
 
   const { guestLocale } = useGuestLocale();
@@ -144,8 +144,6 @@ export const AuthProvider = ({ children, defaultValue, httpClient }) => {
   useEffect(() => {
     validateSession();
   }, [validateSession]);
-
-  useEffect(() => {});
 
   useEffect(() => {
     if (session) {

--- a/src/features/auth/hooks/auth.js
+++ b/src/features/auth/hooks/auth.js
@@ -1,8 +1,4 @@
 import { useContext } from 'react';
 import { AuthContext } from '../context';
 
-// TODO: check if we want to abstract some stuff here
-// maybe make the AuthProvider more lightweight?
-// maybe convert it to use useReducer and make api requests here?
-
 export const useAuth = () => useContext(AuthContext);

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -1,4 +1,3 @@
-// export * from './actions';
 export * from './pages';
 export * from './hooks/auth';
 export * from './context';

--- a/src/features/auth/services/middleware.js
+++ b/src/features/auth/services/middleware.js
@@ -6,10 +6,7 @@ export const applyInterceptors = (client, session) => {
     if (session) {
       Object.assign(config.headers, session);
     } else {
-      Object.assign(
-        config.params
-        // { locale: guestLocale }
-      );
+      Object.assign(config.params, { locale: 'en' });
     }
 
     return config;
@@ -18,15 +15,15 @@ export const applyInterceptors = (client, session) => {
   responseInterceptor = client.interceptors.response.use(
     (response) => response,
     (error) => {
-      if (!error.data) {
+      if (!error.response || !error.response.data) {
         return Promise.reject({ errors: ['Connection error'] });
       }
 
-      if (error.status === 401) {
+      if (error.response.status === 401) {
         // AuthRef.current.clearSession();
       }
 
-      return Promise.reject(error.data);
+      return Promise.reject(error.response.data);
     }
   );
 

--- a/src/helpers/decamelize.test.js
+++ b/src/helpers/decamelize.test.js
@@ -1,7 +1,7 @@
 import { decamelizeKeys } from 'helpers/decamelize';
 
 describe('decamelizeKey', () => {
-  it('should deeply decamelize the keys of an object', () => {
+  it('deeply decamelizes the keys of an object', () => {
     const fakeDate = new Date(2016, 3, 15);
 
     const obj = {
@@ -21,7 +21,7 @@ describe('decamelizeKey', () => {
     });
   });
 
-  it('should raise an error if decamelized key would overwrite existing key of the object', () => {
+  it('raises an error if decamelized key would overwrite existing key of the object', () => {
     const invalidObj = { fooBar: 1, foo_bar: 2 };
     const validObj = { fooBar: 1, fooBaz: 2 };
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,16 +1,11 @@
 import React, { StrictMode } from 'react';
 import { render } from 'react-dom';
-// import { Provider } from 'react-redux';
-// import { PersistGate } from 'redux-persist/integration/react';
 import { ThemeProvider } from '@emotion/react';
 
 import App from 'features/app/components/App';
-// import configureStore from 'store';
 import httpClient from 'features/app/services/httpClient';
+import { AuthProvider } from 'features/auth';
 import theme from 'theme';
-
-// const { store, persistor } = configureStore();
-// applyMiddlewares(httpClient, store);
 
 jest.mock('react-dom', () => ({ render: jest.fn() }));
 
@@ -25,13 +20,11 @@ describe('index.js', () => {
 
     render(
       <StrictMode>
-        {/* <Provider store={store}> */}
-        {/* <PersistGate persistor={persistor}> */}
         <ThemeProvider theme={theme}>
-          <App />
+          <AuthProvider httpClient={httpClient}>
+            <App />
+          </AuthProvider>
         </ThemeProvider>
-        {/* </PersistGate> */}
-        {/* // </Provider> */}
       </StrictMode>,
       root
     );

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,12 +1,10 @@
 import httpAdapter from 'axios/lib/adapters/http';
-
 import httpClient from 'features/app/services/httpClient';
 
 beforeAll(() => {
   httpClient.defaults.adapter = httpAdapter;
 });
 
-afterEach(() => {
-  httpClient.interceptors.request.handlers = [];
-  httpClient.interceptors.response.handlers = [];
+beforeEach(() => {
+  localStorage.clear();
 });

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -21,7 +21,7 @@ const renderWithProviders = (
     <GuestLocaleProvider>
       <IntlProvider locale="en" messages={flatten(AppLocale.en.messages)}>
         <ThemeProvider theme={theme}>
-          <AuthProvider httpClient={httpClient}>
+          <AuthProvider defaultValue={state?.auth} httpClient={httpClient}>
             <Router history={history}>{children}</Router>
           </AuthProvider>
         </ThemeProvider>

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -21,7 +21,7 @@ const renderWithProviders = (
     <GuestLocaleProvider>
       <IntlProvider locale="en" messages={flatten(AppLocale.en.messages)}>
         <ThemeProvider theme={theme}>
-          <AuthProvider defaultValue={state?.auth} httpClient={httpClient}>
+          <AuthProvider prepopulatedState={state?.auth} httpClient={httpClient}>
             <Router history={history}>{children}</Router>
           </AuthProvider>
         </ThemeProvider>

--- a/src/testUtils/mocks/auth.js
+++ b/src/testUtils/mocks/auth.js
@@ -52,7 +52,9 @@ export const mockSignInFailure = (credentials) =>
     });
 
 export const mockUpdateUserSuccess = (user, passwordCheck) => {
-  const body = passwordCheck ? { user, passwordCheck } : { user };
+  const body = passwordCheck
+    ? { user, passwordCheck }
+    : { user, passwordCheck: null };
 
   return baseMock
     .patch('/user', decamelizeKeys(body))
@@ -60,7 +62,9 @@ export const mockUpdateUserSuccess = (user, passwordCheck) => {
 };
 
 export const mockUpdateUserFailure = (user, passwordCheck) => {
-  const body = passwordCheck ? { user, passwordCheck } : { user };
+  const body = passwordCheck
+    ? { user, passwordCheck }
+    : { user, passwordCheck: null };
 
   return baseMock.patch('/user', decamelizeKeys(body)).reply(400, {
     errors: ['Some scary error'],


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR adds a refactor in some test implementations in order to don't depend on Redux and work well with context.

---

#### :pushpin: Notes:
* We added a new prop to the `AuthProvider` in order to "populate" the auth state in our tests (`defaultState`). It could be an implementation that it's just for testing purposes and that is not good, let me know if you find another way to resolve it.

---

#### :heavy_check_mark: Tasks:

* Refactored some API mocks.
* Refactored some test descriptions in order to be consistent with our tests throughout the project.
* Added locale to API interceptors and refactored the way to get the errors.
* Added `AuthProvider` to `renderWithProviders` custom render function.

---

#### :play_or_pause_button: Demo:
![Screen Shot 2021-03-12 at 11 28 17](https://user-images.githubusercontent.com/67390791/110953377-0d4bcf00-8326-11eb-8c02-bfd2086d7232.png)


@loopstudio/react-devs
