### PR TITLE
Fix fontawesome warnings

### DIFF
--- a/src/assets/icons.js
+++ b/src/assets/icons.js
@@ -1,3 +1,5 @@
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 
-export default [faBars];
+const icons = [faBars];
+
+export default icons;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,6 @@
 import httpAdapter from 'axios/lib/adapters/http';
 import { library } from '@fortawesome/fontawesome-svg-core';
+
 import httpClient from 'features/app/services/httpClient';
 import icons from 'assets/icons';
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,8 +1,11 @@
 import httpAdapter from 'axios/lib/adapters/http';
+import { library } from '@fortawesome/fontawesome-svg-core';
 import httpClient from 'features/app/services/httpClient';
+import icons from 'assets/icons';
 
 beforeAll(() => {
   httpClient.defaults.adapter = httpAdapter;
+  library.add(icons);
 });
 
 beforeEach(() => {


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR solves the fontawesome warning by including the icons to the library

---

#### :play_or_pause_button: Demo:
<img width="1280" alt="Screen Shot 2021-04-07 at 1 24 51 PM" src="https://user-images.githubusercontent.com/80699310/113901039-20dc3f80-97d7-11eb-8441-da9c9c0a82d8.png">

@loopstudio/react-devs
