### PR TITLE
Fix issues with forms responsiveness

### DIFF
--- a/src/features/app/components/Form/Form.styles.js
+++ b/src/features/app/components/Form/Form.styles.js
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Link } from 'react-router-dom';
 
 export const Button = styled.button`
   background-color: ${(props) => props.theme.color.indigo600};
@@ -41,15 +40,6 @@ export const FormContent = styled.form`
   ${(props) => props.styles};
 `;
 
-export const HelpLink = styled(Link)`
-  color: ${(props) => props.theme.color.blue700};
-  margin-bottom: 0.25rem;
-
-  &:hover {
-    color: ${(props) => props.theme.color.blue800};
-  }
-`;
-
 export const Input = styled.input`
   background-color: ${(props) => props.theme.color.gray100};
   border-radius: ${(props) => props.theme.borderRadius.base};
@@ -58,6 +48,7 @@ export const Input = styled.input`
   font-size: ${(props) => props.theme.fontSize.sm};
   height: 2.5rem;
   line-height: 1.25;
+  max-width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   width: 16rem;
@@ -109,6 +100,7 @@ export const Select = styled.select`
   color: ${(props) => props.theme.color.gray700};
   height: 2.5rem;
   line-height: 1.25;
+  max-width: 100%;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   width: 16rem;

--- a/src/features/app/components/Form/Input.js
+++ b/src/features/app/components/Form/Input.js
@@ -5,7 +5,7 @@ import InputLabel from './InputLabel';
 
 import { Error, Input, InputContainer } from './Form.styles';
 
-const FormInput = ({ helpLinkPath, helpMessage, id, name, label, ...rest }) => {
+const FormInput = ({ id, name, label, ...rest }) => {
   const {
     register,
     formState: { errors },
@@ -14,13 +14,7 @@ const FormInput = ({ helpLinkPath, helpMessage, id, name, label, ...rest }) => {
 
   return (
     <InputContainer hasError={Boolean(error)}>
-      <InputLabel
-        helpLinkPath={helpLinkPath}
-        helpMessage={helpMessage}
-        htmlFor={id ?? name}
-        label={label}
-        name={name}
-      />
+      <InputLabel htmlFor={id ?? name} label={label} name={name} />
       <Input {...rest} id={id ?? name} {...register(name)} />
       <Error>{error?.message}</Error>
     </InputContainer>
@@ -28,16 +22,12 @@ const FormInput = ({ helpLinkPath, helpMessage, id, name, label, ...rest }) => {
 };
 
 FormInput.defaultProps = {
-  helpLinkPath: '',
-  helpMessage: '',
   id: null,
   label: null,
   type: 'text',
 };
 
 FormInput.propTypes = {
-  helpLinkPath: PropTypes.string,
-  helpMessage: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,
   name: PropTypes.string.isRequired,

--- a/src/features/app/components/Form/InputLabel.js
+++ b/src/features/app/components/Form/InputLabel.js
@@ -1,27 +1,22 @@
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { HelpLink, Label, LabelContent, Span } from './Form.styles';
+import { Label, LabelContent, Span } from './Form.styles';
 
-const InputLabel = ({ helpLinkPath, helpMessage, htmlFor, name, label }) => (
+const InputLabel = ({ htmlFor, name, label }) => (
   <LabelContent>
     <Label htmlFor={htmlFor}>
       <Span>{label ?? <FormattedMessage id={`common.${name}`} />}</Span>
     </Label>
-    {helpLinkPath && <HelpLink to={helpLinkPath}>{helpMessage}</HelpLink>}
   </LabelContent>
 );
 
 InputLabel.defaultProps = {
-  helpLinkPath: '',
-  helpMessage: '',
   label: null,
 };
 
 InputLabel.propTypes = {
   name: PropTypes.string.isRequired,
-  helpLinkPath: PropTypes.string,
-  helpMessage: PropTypes.string,
   htmlFor: PropTypes.string.isRequired,
   label: PropTypes.string,
 };

--- a/src/features/app/components/Form/Select.js
+++ b/src/features/app/components/Form/Select.js
@@ -6,15 +6,7 @@ import InputLabel from './InputLabel';
 
 import { Error, InputContainer, Select } from './Form.styles';
 
-const FormSelect = ({
-  helpLinkPath,
-  helpMessage,
-  id,
-  name,
-  options,
-  label,
-  ...rest
-}) => {
+const FormSelect = ({ id, name, options, label, ...rest }) => {
   const intl = useIntl();
   const {
     register,
@@ -24,13 +16,7 @@ const FormSelect = ({
 
   return (
     <InputContainer hasError={Boolean(error)}>
-      <InputLabel
-        helpLinkPath={helpLinkPath}
-        helpMessage={helpMessage}
-        htmlFor={id ?? name}
-        label={label}
-        name={name}
-      />
+      <InputLabel htmlFor={id ?? name} label={label} name={name} />
       <Select
         {...rest}
         id={id ?? name}
@@ -50,17 +36,13 @@ const FormSelect = ({
 };
 
 FormSelect.defaultProps = {
-  helpLinkPath: '',
   id: null,
-  helpMessage: '',
   label: null,
 };
 
 FormSelect.propTypes = {
   name: PropTypes.string.isRequired,
-  helpLinkPath: PropTypes.string,
   id: PropTypes.string,
-  helpMessage: PropTypes.string,
   label: PropTypes.string,
   options: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/features/auth/components/AuthWrapper/AuthWrapper.styles.js
+++ b/src/features/auth/components/AuthWrapper/AuthWrapper.styles.js
@@ -19,7 +19,7 @@ export const AuthContainer = styled.div`
   flex-direction: column;
   margin-top: 1rem;
   margin-bottom: 1rem;
-  max-width: 24rem;
+  max-width: 95vw;
   padding: 2.5rem 3rem;
 `;
 

--- a/src/features/auth/components/SignIn/Form.js
+++ b/src/features/auth/components/SignIn/Form.js
@@ -1,14 +1,15 @@
-/* eslint-disable jsx-a11y/tabindex-no-positive */
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 import { object, string } from 'yup';
 
 import { useAuth } from 'features/auth';
 import Form from 'features/app/components/Form';
 import { handleErrors } from 'helpers/errors';
+
+import { ForgotPasswordLink } from './SignIn.styles';
 
 const SignInForm = () => {
   const { signIn } = useAuth();
@@ -42,14 +43,13 @@ const SignInForm = () => {
       formMethods={formMethods}
       onSubmit={onSubmit}
     >
-      <Form.Input name="email" tabIndex="1" type="email" />
-      <Form.Input
-        helpLinkPath="/forgot-password"
-        helpMessage={intl.messages['common.forgotPassword']}
-        name="password"
-        tabIndex="2"
-        type="password"
-      />
+      <Form.Input name="email" type="email" />
+      <Form.Input name="password" type="password" />
+      <div>
+        <ForgotPasswordLink to="/forgot-password">
+          <FormattedMessage id="common.forgotPassword" />
+        </ForgotPasswordLink>
+      </div>
       <Form.Button
         isLoading={isLoading}
         text={intl.messages['common.signIn']}

--- a/src/features/auth/components/SignIn/Form.js
+++ b/src/features/auth/components/SignIn/Form.js
@@ -45,11 +45,9 @@ const SignInForm = () => {
     >
       <Form.Input name="email" type="email" />
       <Form.Input name="password" type="password" />
-      <div>
-        <ForgotPasswordLink to="/forgot-password">
-          <FormattedMessage id="common.forgotPassword" />
-        </ForgotPasswordLink>
-      </div>
+      <ForgotPasswordLink to="/forgot-password">
+        <FormattedMessage id="common.forgotPassword" />
+      </ForgotPasswordLink>
       <Form.Button
         isLoading={isLoading}
         text={intl.messages['common.signIn']}

--- a/src/features/auth/components/SignIn/SignIn.styles.js
+++ b/src/features/auth/components/SignIn/SignIn.styles.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 
 export const ForgotPasswordLink = styled(Link)`
   color: ${(props) => props.theme.color.blue700};
+  display: block;
   margin-bottom: 0.25rem;
   margin-left: 0.25rem;
   white-space: nowrap;

--- a/src/features/auth/components/SignIn/SignIn.styles.js
+++ b/src/features/auth/components/SignIn/SignIn.styles.js
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
+
+export const ForgotPasswordLink = styled(Link)`
+  color: ${(props) => props.theme.color.blue700};
+  margin-bottom: 0.25rem;
+  margin-left: 0.25rem;
+  white-space: nowrap;
+  width: 100%;
+
+  &:hover {
+    color: ${(props) => props.theme.color.blue800};
+  }
+`;


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR fixes issues with forms responsiveness.

---

#### :pushpin: Notes:

* Removed `helpMessage` and `helpLinkPath` props from `<Form.Input />`, as they are not being used anywhere and they don't seem to provide any useful applications.
* **TODO:** Fix language selector overlap.

---

#### :heavy_check_mark: Tasks:

* Prevent `AuthWrapper` and Form Inputs from being wider than the smaller viewports.
* Move the `"Forgot Password?"` link below the inputs in the `SignIn` form.

---

#### :play_or_pause_button: Demo:

https://www.loom.com/share/8a92aac4f85f4abfa4ab0a8479640988

@loopstudio/react-devs
