### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elestu @mconiglio @valefranchi @aperezcristina @tiago-zarzavidjian @seedwalk @rlezuez @majitoven @rndelpuerto @nicocadq @jlopeza33 @mminetti @gonchihernandez
+* @loopstudio/react-devs


### PR DESCRIPTION
Use the team to avoid having to manually add/remove members