### PR TITLE
Fix eslint errors for Typescript files imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,8 @@
     "import/ignore": ["/testUtils"],
     "import/resolver": {
       "node": {
-        "moduleDirectory": ["node_modules", "src/"]
+        "moduleDirectory": ["node_modules", "src/"],
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     }
   },
@@ -29,6 +30,16 @@
     "no-console": "warn",
     "import/no-cycle": "off",
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "import/extensions": [
+      "error",
+      "always",
+      {
+        "js": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never"
+      }
+    ],
     "import/prefer-default-export": "off",
     "react/forbid-prop-types": "off",
     "react/jsx-props-no-spreading": "off",

--- a/src/features/auth/components/SignIn/index.js
+++ b/src/features/auth/components/SignIn/index.js
@@ -1,1 +1,1 @@
-export { default } from 'features/auth/components/SignIn/SignIn.tsx';
+export { default } from 'features/auth/components/SignIn/SignIn';


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR fixes `eslint` errors when importing `.ts` or `.tsx` without their extensions.

---

#### :heavy_check_mark: Tasks:

* Modify `import/extensions` eslint rule.
* Add `"extensions": [".js", ".jsx", ".ts", ".tsx"]` to node `import/resolver`.

---

#### :play_or_pause_button: Demo:

Before:
![image](https://user-images.githubusercontent.com/60147387/120216073-ec03cc00-c20c-11eb-8acb-a2d1a946de4c.png)

Now:
![image](https://user-images.githubusercontent.com/60147387/120221155-46545b00-c214-11eb-90dc-8600b7ca6e34.png)


@loopstudio/react-devs
