### PR TITLE
Convert Input component to Typescript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ node_modules/
 src/serviceWorker.js
 yarn.lock
 package.json
+/**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "@types/react-intl": "^3.0.0",
+    "@types/react-router-dom": "^5.1.8",
     "decamelize": "^4.0.0",
     "eslint-config-airbnb": "18.2.0",
     "eslint-config-prettier": "^6.11.0",

--- a/src/emotion.d.ts
+++ b/src/emotion.d.ts
@@ -1,0 +1,79 @@
+import '@emotion/react';
+
+declare module '@emotion/react' {
+  export interface BorderRadius {
+    none: string;
+    sm: string;
+    base: string;
+    md: string;
+    lg: string;
+    full: string;
+  }
+
+  export interface BoxShadow {
+    base: string;
+    darkMd: string;
+    darkLg: string;
+    darkXl: string;
+    indigo: string;
+    none: string;
+  }
+
+  export interface Color {
+    black: string;
+    blue700: string;
+    blue800: string;
+    gray100: string;
+    gray200: string;
+    gray300: string;
+    gray600: string;
+    gray700: string;
+    gray800: string;
+    green700: string;
+    green800: string;
+    indigo200: string;
+    indigo400: string;
+    indigo500: string;
+    indigo600: string;
+    indigo700: string;
+    red600: string;
+    white: string;
+  }
+
+  export interface FontSize {
+    xs: string;
+    sm: string;
+    base: string;
+    lg: string;
+    xl: string;
+    xxl: string;
+    x3l: string;
+    x4l: string;
+    x5l: string;
+    x6l: string;
+    x7l: string;
+    x8l: string;
+  }
+
+  export interface Height {
+    header: string;
+  }
+
+  export interface LetterSpacing {
+    tighter: string;
+    tight: string;
+    normal: string;
+    wide: string;
+    wider: string;
+    widest: string;
+  }
+
+  export interface Theme {
+    borderRadius: BorderRadius;
+    boxShadow: BoxShadow;
+    color: Color;
+    fontSize: FontSize;
+    height: Height;
+    letterSpacing: LetterSpacing;
+  }
+}

--- a/src/features/app/components/Form/Button.tsx
+++ b/src/features/app/components/Form/Button.tsx
@@ -2,9 +2,7 @@ import { ButtonHTMLAttributes, forwardRef, Ref } from 'react';
 import { MessageFormatElement } from 'react-intl';
 import { SerializedStyles } from '@emotion/react';
 
-import Loading from '../Loading';
-
-import { Button, loadingStyles } from './Form.styles';
+import { Button, CustomLoading } from './Form.styles';
 
 interface FormButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isDisabled?: boolean;
@@ -24,7 +22,7 @@ const FormButton = forwardRef(
       disabled={isDisabled || isLoading}
       {...rest}
     >
-      {isLoading ? <Loading styles={loadingStyles} /> : text}
+      {isLoading ? <CustomLoading /> : text}
     </Button>
   )
 );

--- a/src/features/app/components/Form/Form.styles.ts
+++ b/src/features/app/components/Form/Form.styles.ts
@@ -1,5 +1,5 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import Loading from '../Loading';
 
 interface InputContainerProps {
   hasError: boolean;
@@ -9,7 +9,7 @@ interface StylesProps {
   styles?: any;
 }
 
-export const Button = styled.button<StylesProps>`
+export const Button = styled.button`
   background-color: ${(props) => props.theme.color.indigo600};
   border-radius: ${(props) => props.theme.borderRadius.base};
   box-shadow: ${(props) => props.theme.boxShadow.base};
@@ -33,8 +33,6 @@ export const Button = styled.button<StylesProps>`
     background-color: ${(props) => props.theme.color.indigo200};
     box-shadow: ${(props) => props.theme.boxShadow.none};
   }
-
-  ${(props) => props.styles};
 `;
 
 export const Error = styled.span`
@@ -48,7 +46,7 @@ export const FormContent = styled.form<StylesProps>`
   ${(props) => props.styles};
 `;
 
-export const Input = styled.input<StylesProps>`
+export const Input = styled.input`
   background-color: ${(props) => props.theme.color.gray100};
   border-radius: ${(props) => props.theme.borderRadius.base};
   border-width: 1px;
@@ -65,8 +63,6 @@ export const Input = styled.input<StylesProps>`
     border-color: ${(props) => props.theme.color.gray300};
     outline: 0;
   }
-
-  ${(props) => props.styles};
 `;
 
 export const InputContainer = styled.div<InputContainerProps>`
@@ -96,7 +92,7 @@ export const LabelContent = styled.div`
   justify-content: space-between;
 `;
 
-export const loadingStyles = css`
+export const CustomLoading = styled(Loading)`
   margin-top: -0.5rem;
   margin-bottom: -0.5rem;
 `;

--- a/src/features/app/components/Form/Form.styles.ts
+++ b/src/features/app/components/Form/Form.styles.ts
@@ -1,7 +1,15 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Button = styled.button`
+interface InputContainerProps {
+  hasError: boolean;
+}
+
+interface StylesProps {
+  styles?: any;
+}
+
+export const Button = styled.button<StylesProps>`
   background-color: ${(props) => props.theme.color.indigo600};
   border-radius: ${(props) => props.theme.borderRadius.base};
   box-shadow: ${(props) => props.theme.boxShadow.base};
@@ -36,11 +44,11 @@ export const Error = styled.span`
   max-width: fit-content;
 `;
 
-export const FormContent = styled.form`
+export const FormContent = styled.form<StylesProps>`
   ${(props) => props.styles};
 `;
 
-export const Input = styled.input`
+export const Input = styled.input<StylesProps>`
   background-color: ${(props) => props.theme.color.gray100};
   border-radius: ${(props) => props.theme.borderRadius.base};
   border-width: 1px;
@@ -61,7 +69,7 @@ export const Input = styled.input`
   ${(props) => props.styles};
 `;
 
-export const InputContainer = styled.div`
+export const InputContainer = styled.div<InputContainerProps>`
   margin-bottom: 0.75rem;
   margin-top: ${({ hasError }) => hasError && '0.25rem'};
 

--- a/src/features/app/components/Form/Input.tsx
+++ b/src/features/app/components/Form/Input.tsx
@@ -1,10 +1,11 @@
+import { InputHTMLAttributes } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import InputLabel from './InputLabel';
 
 import { Error, Input, InputContainer } from './Form.styles';
 
-interface FormInputProps {
+interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
   id: string;
   name: string;
   label: string;

--- a/src/features/app/components/Form/Input.tsx
+++ b/src/features/app/components/Form/Input.tsx
@@ -1,11 +1,16 @@
-import PropTypes from 'prop-types';
 import { useFormContext } from 'react-hook-form';
 
 import InputLabel from './InputLabel';
 
 import { Error, Input, InputContainer } from './Form.styles';
 
-const FormInput = ({ id, name, label, ...rest }) => {
+interface FormInputProps {
+  id: string;
+  name: string;
+  label: string;
+}
+
+const FormInput = ({ id, name, label, ...rest }: FormInputProps) => {
   const {
     register,
     formState: { errors },
@@ -19,19 +24,6 @@ const FormInput = ({ id, name, label, ...rest }) => {
       <Error>{error?.message}</Error>
     </InputContainer>
   );
-};
-
-FormInput.defaultProps = {
-  id: null,
-  label: null,
-  type: 'text',
-};
-
-FormInput.propTypes = {
-  id: PropTypes.string,
-  label: PropTypes.string,
-  name: PropTypes.string.isRequired,
-  type: PropTypes.string,
 };
 
 export default FormInput;

--- a/src/features/app/components/Loading/Loading.js
+++ b/src/features/app/components/Loading/Loading.js
@@ -7,8 +7,8 @@ import {
   DoubleBounceWithDelay,
 } from './Loading.styles';
 
-const Loading = ({ styles }) => (
-  <Wrapper styles={styles}>
+const Loading = ({ styles, className }) => (
+  <Wrapper styles={styles} className={className}>
     <Spinner>
       <DoubleBounce />
       <DoubleBounceWithDelay />
@@ -17,10 +17,12 @@ const Loading = ({ styles }) => (
 );
 
 Loading.defaultProps = {
+  className: '',
   styles: {},
 };
 
 Loading.propTypes = {
+  className: PropTypes.string,
   styles: PropTypes.object,
 };
 

--- a/src/features/app/components/Settings/ChangePasswordForm.js
+++ b/src/features/app/components/Settings/ChangePasswordForm.js
@@ -8,7 +8,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import Form from 'features/app/components/Form';
 import { handleErrors } from 'helpers/errors';
 
-import { SuccessText, formStyles, buttonStyles } from './Settings.styles';
+import { SuccessText, StyledForm, FormButton } from './Settings.styles';
 
 const ChangePasswordForm = () => {
   const intl = useIntl();
@@ -43,7 +43,7 @@ const ChangePasswordForm = () => {
   };
 
   return (
-    <Form formMethods={formMethods} onSubmit={onSubmit} styles={formStyles}>
+    <StyledForm formMethods={formMethods} onSubmit={onSubmit}>
       <Form.Input
         label={intl.messages['common.currentPassword']}
         name="currentPassword"
@@ -54,9 +54,8 @@ const ChangePasswordForm = () => {
         name="password"
         type="password"
       />
-      <Form.Button
+      <FormButton
         isLoading={isLoading}
-        styles={buttonStyles}
         text={intl.messages['common.updatePassword']}
       />
       {isResponseSuccess && (
@@ -64,7 +63,7 @@ const ChangePasswordForm = () => {
           <FormattedMessage id="common.changePasswordSuccess" />
         </SuccessText>
       )}
-    </Form>
+    </StyledForm>
   );
 };
 

--- a/src/features/app/components/Settings/Form.js
+++ b/src/features/app/components/Settings/Form.js
@@ -8,7 +8,7 @@ import { object, string } from 'yup';
 import Form from 'features/app/components/Form';
 import { handleErrors } from 'helpers/errors';
 
-import { SuccessText, formStyles, buttonStyles } from './Settings.styles';
+import { SuccessText, StyledForm, FormButton } from './Settings.styles';
 
 const SettingsForm = () => {
   const intl = useIntl();
@@ -46,7 +46,7 @@ const SettingsForm = () => {
   };
 
   return (
-    <Form formMethods={formMethods} onSubmit={onSubmit} styles={formStyles}>
+    <StyledForm formMethods={formMethods} onSubmit={onSubmit}>
       <Form.Input name="firstName" />
       <Form.Input name="lastName" />
       <Form.Select
@@ -56,9 +56,8 @@ const SettingsForm = () => {
           { value: 'es', label: 'Español' },
         ]}
       />
-      <Form.Button
+      <FormButton
         isLoading={isLoading}
-        styles={buttonStyles}
         text={intl.messages['common.updateSettings']}
       />
       {isResponseSuccess && (
@@ -66,7 +65,7 @@ const SettingsForm = () => {
           <FormattedMessage id="common.updateSettingsSuccess" />
         </SuccessText>
       )}
-    </Form>
+    </StyledForm>
   );
 };
 

--- a/src/features/app/components/Settings/Settings.styles.js
+++ b/src/features/app/components/Settings/Settings.styles.js
@@ -1,5 +1,19 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
+import Form from 'features/app/components/Form';
+
+export const StyledForm = styled(Form)`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  margin-top: 1.5rem;
+  width: fit-content;
+`;
+
+export const FormButton = styled(Form.Button)`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  width: 16rem;
+`;
 
 export const SettingsContainer = styled.div`
   background-color: ${(props) => props.theme.color.gray200};
@@ -31,18 +45,4 @@ export const SettingsTitle = styled.h2`
 
 export const SuccessText = styled.p`
   color: ${(props) => props.theme.color.green700};
-`;
-
-export const formStyles = css`
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-  margin-top: 1.5rem;
-  width: fit-content;
-`;
-
-export const buttonStyles = css`
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-  width: 16rem;
 `;

--- a/src/features/auth/components/ForgotPassword/EmailForm.js
+++ b/src/features/auth/components/ForgotPassword/EmailForm.js
@@ -12,7 +12,7 @@ import { handleErrors } from 'helpers/errors';
 import { RESET_PASSWORD_STEPS } from 'features/auth/components/ForgotPassword/ForgotPassword';
 
 import {
-  inputStyles,
+  FormInput,
   Legend,
 } from 'features/auth/components/ForgotPassword/ForgotPassword.styles';
 
@@ -50,7 +50,7 @@ const EmailForm = ({ onStepChange }) => {
       <Legend>
         <FormattedMessage id="common.forgotPasswordLegend" />
       </Legend>
-      <Form.Input styles={inputStyles} name="email" type="email" />
+      <FormInput name="email" type="email" />
       <Form.Button text={intl.messages['common.resetPassword']} />
       {loading && <Loading />}
     </Form>

--- a/src/features/auth/components/ForgotPassword/ForgotPassword.styles.js
+++ b/src/features/auth/components/ForgotPassword/ForgotPassword.styles.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
+import Form from 'features/app/components/Form';
 
-export const inputStyles = css`
+export const FormInput = styled(Form.Input)`
   width: 100%;
 `;
 

--- a/src/features/auth/components/ForgotPassword/PasswordForm.js
+++ b/src/features/auth/components/ForgotPassword/PasswordForm.js
@@ -13,7 +13,7 @@ import { handleErrors } from 'helpers/errors';
 
 import {
   Legend,
-  inputStyles,
+  FormInput,
 } from 'features/auth/components/ForgotPassword/ForgotPassword.styles';
 
 const PasswordForm = ({ token }) => {
@@ -58,8 +58,8 @@ const PasswordForm = ({ token }) => {
       <Legend>
         <FormattedMessage id="common.forgotPasswordChange" />
       </Legend>
-      <Form.Input styles={inputStyles} name="password" type="password" />
-      <Form.Input styles={inputStyles} name="confirmPassword" type="password" />
+      <FormInput name="password" type="password" />
+      <FormInput name="confirmPassword" type="password" />
       <Form.Button text={intl.messages['common.next']} />
       {loading && <Loading />}
     </Form>

--- a/src/features/auth/components/ForgotPassword/TokenForm.js
+++ b/src/features/auth/components/ForgotPassword/TokenForm.js
@@ -13,7 +13,7 @@ import { RESET_PASSWORD_STEPS } from 'features/auth/components/ForgotPassword/Fo
 
 import {
   Legend,
-  inputStyles,
+  FormInput,
   LinkButton,
 } from 'features/auth/components/ForgotPassword/ForgotPassword.styles';
 
@@ -54,7 +54,7 @@ const TokenForm = ({ onStepChange, onSaveToken }) => {
       <Legend>
         <FormattedMessage id="common.forgotPasswordEmailSent" />
       </Legend>
-      <Form.Input styles={inputStyles} name="token" type="number" />
+      <FormInput name="token" type="number" />
       <LinkButton
         type="button"
         onClick={() => onStepChange(RESET_PASSWORD_STEPS.initial)}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,6 @@
-const theme = {
+import { Theme } from '@emotion/react';
+
+const theme: Theme = {
   borderRadius: {
     none: '0',
     sm: '0.125rem',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,5 @@
     "jsx": "react-jsx",
     "baseUrl": "src"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2701,6 +2701,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.9.tgz#1cfb6d60ef3822c589f18e70f8b12f9a28ce8724"
+  integrity sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -2825,6 +2830,23 @@
   integrity sha512-k8F3d05XQGEqSWIfK97bBjZe4z9RruXU9Wa7OZ2iUC5pdeIpzuQDZe/9C2J3Xir5//ZtAkhcv08Wfx3n5TBTQg==
   dependencies:
     react-intl "*"
+
+"@types/react-router-dom@^5.1.8":
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.8.tgz#bf3e1c8149b3d62eaa206d58599de82df0241192"
+  integrity sha512-03xHyncBzG0PmDmf8pf3rehtjY0NpUj7TIN46FrT5n1ZWHPZvXz32gUyNboJ+xsL8cpg8bQVLcllptcQHvocrw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.16.tgz#f3ba045fb96634e38b21531c482f9aeb37608a99"
+  integrity sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react@*":
   version "16.9.55"


### PR DESCRIPTION
#### :page_facing_up: Description:

This PR converts the Input component to TypeScript. To achieve this I had to type the theme to work with `.ts` styles files, as they make use of the props we pass to the styled-components.

---

#### :pushpin: Notes:

* For more information/doubts you may have regarding the theme or styles, read [this](https://emotion.sh/docs/typescript)  docs from `emotion`.
* TODO: refactor the rest of the custom styles in the app, using the `styled(Component)` syntax.

---

#### :heavy_check_mark: Tasks:

* Define `Theme` interface.
* Avoid `eslint` warnings from `.d.ts` files.
* Type `FormInput` component.
* Type component styles file.
* Define styles' interfaces.
* Refactor the way we customize styles for the Form related components.
* Install `@types/react-router-dom`.

@loopstudio/react-devs
