### PR TITLE
Use loop-react-auth from NPM registry

### DIFF
--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,7 +1,3 @@
-# @loopstudio's github packages configuration
-@loopstudio:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=YOUR-PERSONAL-ACCESS-TOKEN
-
 # Font Awesome Pro configuration.
 @fortawesome:registry=https://npm.fontawesome.com/
 //npm.fontawesome.com/:_authToken=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
     "@hookform/resolvers": "2.8.1",
-    "@loopstudio/react-auth": "^1.0.0",
+    "loop-react-auth": "^1.0.0",
     "@types/jest": "^27.0.2",
     "@types/md5": "^2.3.1",
     "@types/node": "^16.10.1",

--- a/src/features/app/components/App/App.js
+++ b/src/features/app/components/App/App.js
@@ -4,7 +4,7 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 import { BrowserRouter } from 'react-router-dom';
 import flatten from 'flat';
 import { Global } from '@emotion/react';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 
 import icons from 'assets/icons';
 import { useGuestLocale } from '../../hooks/guestLocale';

--- a/src/features/app/components/Navbar/Menu.tsx
+++ b/src/features/app/components/Navbar/Menu.tsx
@@ -1,5 +1,5 @@
 import { useHistory } from 'react-router-dom';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 
 import Button from './Button';
 

--- a/src/features/app/components/Navbar/UserOptions.tsx
+++ b/src/features/app/components/Navbar/UserOptions.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import md5 from 'md5';
 
 import Button from './Button';

--- a/src/features/app/components/Settings/ChangePasswordForm.js
+++ b/src/features/app/components/Settings/ChangePasswordForm.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import { useForm } from 'react-hook-form';
 import { object, string } from 'yup';
 import { useIntl, FormattedMessage } from 'react-intl';

--- a/src/features/app/components/Settings/Form.js
+++ b/src/features/app/components/Settings/Form.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import { useForm } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { object, string } from 'yup';

--- a/src/features/app/context/guestLocale.js
+++ b/src/features/app/context/guestLocale.js
@@ -1,5 +1,5 @@
 import { createContext, useState, useEffect } from 'react';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import {
   applyLocaleInterceptor,
   clearLocaleInterceptor,

--- a/src/features/auth/components/ForgotPassword/EmailForm.js
+++ b/src/features/auth/components/ForgotPassword/EmailForm.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import { useForm } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { object, string } from 'yup';

--- a/src/features/auth/components/ForgotPassword/PasswordForm.js
+++ b/src/features/auth/components/ForgotPassword/PasswordForm.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import { useForm } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';

--- a/src/features/auth/components/ForgotPassword/TokenForm.js
+++ b/src/features/auth/components/ForgotPassword/TokenForm.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import { useForm } from 'react-hook-form';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { object, string } from 'yup';

--- a/src/features/auth/components/SignIn/Form.js
+++ b/src/features/auth/components/SignIn/Form.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import { useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';

--- a/src/features/auth/components/SignUp/Form.js
+++ b/src/features/auth/components/SignUp/Form.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useAuth } from '@loopstudio/react-auth';
+import { useAuth } from 'loop-react-auth';
 import { useIntl } from 'react-intl';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React, { StrictMode } from 'react'; // eslint-disable-line no-restricted-imports
 import ReactDOM, { render } from 'react-dom';
 import { ThemeProvider } from '@emotion/react';
-import { AuthProvider } from '@loopstudio/react-auth';
+import { AuthProvider } from 'loop-react-auth';
 
 import { GuestLocaleProvider } from 'features/app/context/guestLocale';
 import App from 'features/app/components/App';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { render } from 'react-dom';
 import { ThemeProvider } from '@emotion/react';
-import { AuthProvider } from '@loopstudio/react-auth';
+import { AuthProvider } from 'loop-react-auth';
 
 import App from 'features/app/components/App';
 import httpClient from 'features/app/services/httpClient';

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -5,7 +5,7 @@ import { Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { ThemeProvider } from '@emotion/react';
-import { AuthProvider } from '@loopstudio/react-auth';
+import { AuthProvider } from 'loop-react-auth';
 import theme from 'theme';
 
 import AppLocale from 'features/app/locales';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2367,11 +2367,6 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@loopstudio/react-auth@^1.0.0":
-  version "1.0.0"
-  resolved "https://npm.pkg.github.com/download/@loopstudio/react-auth/1.0.0/dca6bd813474907b1197632fce4a93bb378930136b2b1a07c1c271bfed0fd68d#6445a813aaa244fb8b9702a22cda69943edfb02d"
-  integrity sha512-gkxrChVhCPPczqOAGOa+2wys4y9HO/09+V00cc61Pzx1Rn6Rk102n132myTFrntOOeJO0Ogkp/8MPhRWFYD02w==
-
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -8583,6 +8578,11 @@ lolex@^5.0.0:
   integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+loop-react-auth@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/loop-react-auth/-/loop-react-auth-1.0.0.tgz#ff957f40afd7326525ea9bc94d66b97ec1a9d185"
+  integrity sha512-rmP4AaK8nQJtRfYWc4ZiJwSq3lFAPzDWU0fhJLHV7M2n6fBws1ckmEvkOhYRCnfQR4d11C9j+GxwdaZotSUw2A==
 
 loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
- By using this lib from NPM we no longer need to add
  github personal access token to install the dependencies.

#### :page_facing_up: Description:

Provide a good description of the problem this PR is trying to address.

---

#### :pushpin: Notes:

* Include TODOS, warnings, things other developers need to be aware of when merging, etc.

---

#### :heavy_check_mark: Tasks:

* Write the list of things you performed to help the reviewer.

---

#### :play_or_pause_button: Demo:
* Include a video or picture.

@loopstudio/react-devs
